### PR TITLE
ci: add HOL skill-publish validate workflow

### DIFF
--- a/.github/workflows/hol-skill-validate.yml
+++ b/.github/workflows/hol-skill-validate.yml
@@ -1,0 +1,30 @@
+name: HOL Skill Validate
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Validate Skill
+        uses: hashgraph-online/skill-publish@4d99459187151e4e55600741e3b4320ab66adfd2
+        with:
+          mode: validate
+          skill-dir: .claude/skills/filesystem-ultra-tools
+          annotate: "false"
+          preview-upload: "false"

--- a/.github/workflows/hol-skill-validate.yml
+++ b/.github/workflows/hol-skill-validate.yml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   contents: read
+  id-token: none
 
 jobs:
   validate:


### PR DESCRIPTION
This adds a validate-only workflow that checks skill metadata without affecting the build or release process.

The workflow runs in validate-only mode and doesn't touch runtime code, release flow, or publish credentials.

This PR adds a single workflow at `.claude/skills/filesystem-ultra-tools` that runs the HOL skill validator in validate mode. It checks schema and trust signals only, makes no changes to runtime code or release flow, and leaves publish credentials untouched.

If you'd prefer this pointed at a different path or folded into an existing workflow, let me know and I can adjust the branch.
