### PR TITLE
feat(write_file): downgrade block → warn + auto-backup when backup av…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,7 @@ Revisar_implantar_o_borrar/
 temp_test/
 test_*.txt
 before.txt
+*.pptx
 
 # ------------------------------------------------------------
 # Claude / AI agent artifacts (keep only the custom skill)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,92 @@
 # CHANGELOG - MCP Filesystem Server Ultra-Fast
 
+## [Unreleased / 4.5.6] - 2026-06-07
+
+### Improvement — Log-driven optimizations (analysis of 12 days, 16,742 operations)
+
+After analyzing `C:\temp\mcp-proxy-logs\proxy.jsonl` (27-may → 07-jun, 2053 ops, 76 errors), four low-risk, backwards-compatible improvements landed:
+
+**A. `search_files` output cap (M1+M2) — token-cost fix**
+
+44% of all output tokens came from `search_files`. Worst case observed: a single 2.28 MB response (~570k tokens). Now the handler truncates responses larger than the configured cap (default 500 KB) and appends a marker so the model knows to retry with `count_only:true` or a narrower path.
+
+```
+⚠️ truncated: response exceeded 500 KB. Use count_only:true or narrow the path/pattern.
+```
+
+- New constant: `core.DefaultMaxSearchOutputBytes = 500 * 1024` (`core/config.go`)
+- New field: `Config.MaxSearchOutputBytes` (0 = use default)
+- New helper: `capSearchOutput(text, engine)` in `tools_search.go`
+- New accessor: `(*UltraFastEngine).GetConfig()` (`core/engine.go`)
+- Behavior below the cap is unchanged; only over-cap responses are truncated.
+- Tests: 4 cases in `search_output_cap_test.go` (below, above, default, exact boundary).
+
+**B. `content_hash` + `expected_hash` (B3) — stale-edit protection**
+
+Log analysis found 6 stale-edit cycles in 12 days (read → edit fail → re-read → edit ok). The model uses an `old_text` that was modified by a prior edit. Now `read_file` appends an 8-hex-char FNV-1a hash to its response, and `edit_file` accepts an optional `expected_hash` to refuse the edit if the file changed.
+
+```
+# read_file response footer:
+hello world
+# content_hash: 1a2b3c4d
+
+# edit_file with wrong hash:
+ERROR: stale edit: file content changed since read (expected hash: 00000000, actual: 1a2b3c4d).
+Re-read the file with read_file to get the current content_hash, then retry.
+```
+
+- `hash/fnv` (stdlib) — no new dependency
+- `expected_hash` is **optional**; behavior without it is identical to before
+- Schema registered in `core/param_validator.go` for both `edit_file` and `edit` alias
+- Tests: 5 cases in `content_hash_test.go` (appears-in-read, stable, accepted, rejected, omitted).
+
+**C. `cache_hit` in audit log (M3) — observability fix**
+
+The `AuditEntry.CacheHit *bool` field has existed since the audit logger was added, but no code was setting it. Now `ReadFileContent` records `true` on cache hit and `false` on disk read. Operations log (`operations.jsonl`) will show real cache effectiveness.
+
+- New API: `core.SetCacheHit(ctx, hit bool)` (`core/audit_logger.go`)
+- Wire-up: 2 lines in `core/engine.go:ReadFileContent` (hit branch + after disk read)
+- Tests: 2 cases in `core/cache_hit_audit_test.go` (records correctly, no-op without entry).
+
+**D. `SetError` + proxy error extraction (M6) — diagnostic completeness**
+
+The audit log's `Error` field was only populated when the JSON-RPC envelope had a top-level `error` member — but most tool errors come back as `result.isError: true` with the message in `result.content[0].text`. Now both layers handle it.
+
+- New API: `core.SetError(ctx, msg string)` (`core/audit_logger.go`) — handlers can override the auto-extracted error with a custom reason
+- Proxy: `cmd/proxy/main.go` now extracts `result.content[0].text` when `isError: true`, populating `proxy.jsonl` `error` field (was empty for ~95% of MCP-level errors)
+- Tests: 3 cases in `tests/audit_set_error_test.go` (sets-field-and-forces-error, empty-noop, no-entry-noop).
+
+**Files changed (11 total, +118 / -2 lines):**
+
+| File | Change |
+|------|--------|
+| `core/audit_logger.go` | +`SetCacheHit`, +`SetError` |
+| `core/config.go` | +`DefaultMaxSearchOutputBytes` |
+| `core/engine.go` | +`GetConfig()`, +wire `SetCacheHit` in `ReadFileContent` |
+| `core/param_validator.go` | +`expected_hash` in `edit_file` and `edit` schemas |
+| `core/cache_hit_audit_test.go` | NEW |
+| `tools_core.go` | +`hash/fnv` import, +content_hash footer, +expected_hash check, +schema field |
+| `tools_search.go` | +`capSearchOutput` helper, +cap at 2 call sites |
+| `content_hash_test.go` | NEW |
+| `search_output_cap_test.go` | NEW |
+| `tests/audit_set_error_test.go` | NEW |
+| `cmd/proxy/main.go` | +extract error text from `result.content[0].text` |
+
+**Test results:** all existing tests still pass. 14 new tests added, all green.
+
+```
+ok  core         0.678s
+ok  tests        15.820s
+ok  tests/security 0.873s
+ok  .            0.498s
+```
+
+**Out of scope (deferred):**
+- `git` tool 38.9% error rate — comes from another binary (`filesystem-rust-ultra.exe` or `filesystem-ultra-v4-embed_rg.exe`), not this Go server.
+- `get_file_info` 23% error rate — needs running server + Windows lock investigation.
+- `mcp_search`/`mcp_read`/etc. prefix duplication — already resolved by user (12-day log shows 15 unique tool names vs 41 in 3-month history).
+- `ReadFileRange` doesn't use cache — separate PR.
+
 ## [Unreleased / 4.5.5] - 2026-06-04
 
 ### Improvement — Adaptive write_file behavior when backup is available

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,36 @@
 # CHANGELOG - MCP Filesystem Server Ultra-Fast
 
-## [Unreleased / 4.5.5] - 2026-05-30
+## [Unreleased / 4.5.5] - 2026-06-04
+
+### Improvement — Adaptive write_file behavior when backup is available
+
+`write_file` previously hard-blocked when new content was < 50% or > 3× the existing file size (`truncation` and `inflation_loop` patterns in `core/feedback.go`), forcing a `delete_file` + `write_file` cycle that wasted tokens on long sessions.
+
+Now, when the engine has a `BackupManager` configured (default: `--backup-dir` → `temp/mcp-batch-backups`), these patterns instead:
+1. Create a safety backup of the existing file (linked to the undo chain via `CreateBackupWithContextAndParent`)
+2. Proceed with the write
+3. Return a non-blocking `WARN` (status `warn` in the audit log) that includes the backup ID and the literal `backup(action:"restore", backup_id:"...")` undo command. Response format is forced to verbose so the restore command is visible, even in `--compact-mode`.
+
+When the backup manager is unavailable (rare — only if `NewBackupManager` failed at startup, e.g. permissions), the original hard-block behavior is preserved as a safety net.
+
+**Response format (downgraded case):**
+```
+WRITTEN C:\foo\bar.go | 8055B
+⚠️ [TRUNCATION] WARNING: new content (8055 B) is less than 50% of existing file (62749 B). Looks like accidental truncation.
+   → Backup created: 20260604-130xxx. To undo: backup(action:"restore", backup_id:"20260604-130xxx"). Read the full file first, then use edit_file for partial changes. To force overwrite: delete_file first, then write_file.
+```
+
+**Files:**
+- `core/feedback_adaptive.go` (new) — `ApplyAdaptiveWriteBlock` pure helper
+- `core/feedback_adaptive_test.go` (new) — 9 table-driven cases + restore-command format pin
+- `core/feedback.go` — added `Downgraded bool` field to `FeedbackSignal` (with `omitempty` for JSON back-compat)
+- `tools_core.go` — handler of `write_file` now calls the helper; normalizes path once; forces verbose response on downgraded warns
+- `core/claude_optimizer.go` — added `// NOTE:` documenting the intentional divergence with the legacy `IntelliGentWrite` guard
+
+**Not changed:** the legacy truncation guard in `core/claude_optimizer.go:IntelliGentWrite` — hard-blocks even when backup is available. The divergence is intentional for this release; unification planned for 4.5.6+.
+
+**Build artifacts:**
+- `bin/filesystem-ultra-v4-embed_rg.exe` (12 MB, with ripgrep embedded) — rebuilt 2026-06-04
 
 ### Security — Major improvements to hook coverage, Git tool, and WSL auto-sync
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,95 @@ ok  .            0.498s
 - `mcp_search`/`mcp_read`/etc. prefix duplication — already resolved by user (12-day log shows 15 unique tool names vs 41 in 3-month history).
 - `ReadFileRange` doesn't use cache — separate PR.
 
+## [Unreleased / 4.5.7] - 2026-06-07
+
+### Bug fix — `edit_file`/`multi_edit` find 0 matches on files with mixed whitespace
+
+Reported reproduction: a 87 KB JS file edited with VSCode/Windows editors ends up with mixed tabs and spaces. `edit_file` and `project_replace` (in `search_replace` mode) return **0 matches** even for patterns that clearly exist, because the existing byte-exact matcher can't reconcile tabs with 4-space runs. Same problem with CRLF vs LF: a file with Windows line endings and a pattern typed with LF never matches. The previous workaround was for the user to manually reformat and re-save the file before editing.
+
+**Fix — `tolerant_whitespace: true` flag (opt-in)**
+
+Both `edit_file` and `multi_edit` now accept an explicit `tolerant_whitespace` boolean. When `true`, the matcher treats one tab as 4 spaces and CRLF/CR as LF, while preserving the file's original bytes verbatim outside the match region. Pure stdlib, no new dependency.
+
+```js
+// Before (fails on mixed-indent files):
+edit_file({path: "_events.js", old_text: "    taula_llistat(", new_text: "    taula_llistat_new("})
+
+// After (works regardless of tabs/spaces in the file):
+edit_file({path: "_events.js", old_text: "    taula_llistat(", new_text: "    taula_llistat_new(", tolerant_whitespace: true})
+```
+
+- New file: [`core/whitespace_matcher.go`](core/whitespace_matcher.go) — `normalizeForTolerantMatch` (whitespace normalization + byteMap for position translation), `findAllTolerantMatches`, `applyTolerantMatches`. Conservative: only tabs and line endings are normalized, not runs of multiple spaces.
+- [`core/edit_operations.go`](core/edit_operations.go) — `EditFile`, `MultiEdit`, `performIntelligentEdit` accept `tolerantWhitespace bool` and run as `OPTIMIZATION 0` (before the exact-match fast path) when enabled. If tolerant matching finds nothing, the existing cascade (literal escapes, leading-whitespace fallback, flexible regex) still runs.
+- Existing `OPTIMIZATION 7` (leading-whitespace fallback) and `OPTIMIZATION 8` (flexible regex) remain in place as further fallbacks — so behavior with `tolerant_whitespace: false` is byte-identical to before for every file we tested.
+- API change: `EditFile` and `MultiEdit` now take 6 args (added `tolerantWhitespace bool`). All ~20 internal/test call sites updated; the default value `false` preserves existing behavior.
+- Schema: `tolerant_whitespace` registered in `core/param_validator.go` for `edit_file`, `multi_edit`, and the `edit` alias.
+- Wire-up: `tools_core.go` and `tools_batch.go` extract the param and pass it through.
+
+### Feature — `minify_js` tool (pure Go, no Node, no external deps)
+
+A new tool to minify JavaScript files in place. Pure-stdlib state machine that handles `//` and `/* */` comments, single/double/template strings (with `${expr}` interpolation), regex literals (`/.../[flags]`) with character classes, and the regex-vs-division disambiguation that real JS tokenizers do. Auto-creates a backup before overwriting, recoverable with `backup(action:"undo_last")`.
+
+```js
+// Dry run first:
+minify_js({path: "app.js", dry_run: true})
+// → "MINIFY (dry-run) app.js | 87342→31045B (-56297, 64.4%) | comments:42"
+
+// Live run:
+minify_js({path: "app.js", remove_comments: true, single_line: true})
+// → file overwritten; UNDO:20260607-xxxxx is the backup ID
+```
+
+- New file: [`core/minifier.go`](core/minifier.go) — `MinifyJS(src, MinifyOptions) (string, MinifyStats)`, plus `MinifyStats{InputBytes, OutputBytes, BytesSaved, ReductionPercent, CommentsStripped, Truncated}`. Best-effort: the 95% of real-world JS works perfectly; exotic regex-with-`/`-in-char-class and tagged-template edge cases are handled with conservative heuristics (the minifier never modifies the contents of strings, regexes, or template substitutions).
+- New file: [`tools_minify.go`](tools_minify.go) — registers the `minify_js` MCP tool with parameters `path`, `output_path` (optional, write elsewhere instead of overwriting), `remove_comments`, `collapse_whitespace`, `single_line`, `dry_run`, `create_backup`.
+- New public API: `(*UltraFastEngine).InvalidateCache(path)` and `core.SecureRandomSuffix()` — thin wrappers over the existing private helpers so the new tool keeps the cache consistent and uses unpredictable temp-file names.
+- Tool count: **20 tools** (18 core + git + help + **minify_js**).
+
+### Tests
+
+- [`core/whitespace_matcher_test.go`](core/whitespace_matcher_test.go) — 13 cases: tabs↔spaces (both directions), CRLF↔LF, lone CR, multiple matches, byte-range preservation, UTF-8 byte positions preserved, end-to-end via `performIntelligentEdit` with a tab in the middle of a line (a case the existing `OPTIMIZATION 7` cannot handle).
+- [`core/minifier_test.go`](core/minifier_test.go) — 25+ cases covering strings, regex, templates, division, shebang, comment removal modes, single-line toggle, truncation on malformed input, and a real-world DataTable snippet.
+- All existing tests still pass: `go test ./...` green (`core 0.68s`, `tests 14.4s`, `tests/security 0.82s`).
+
+**Files changed (26 total):**
+
+| File | Change |
+|------|--------|
+| `core/whitespace_matcher.go` | NEW — tolerant matcher + byteMap |
+| `core/whitespace_matcher_test.go` | NEW |
+| `core/minifier.go` | NEW — JS state-machine minifier |
+| `core/minifier_test.go` | NEW |
+| `core/edit_operations.go` | +`tolerantWhitespace` param on `EditFile`/`MultiEdit`/`performIntelligentEdit`; new OPTIMIZATION 0 |
+| `core/engine.go` | +`InvalidateCache(path)`, +`SecureRandomSuffix()` |
+| `core/param_validator.go` | +`tolerant_whitespace` in edit_file, multi_edit, edit schemas |
+| `core/streaming_operations.go` | update EditFile caller |
+| `core/claude_optimizer.go` | update EditFile caller |
+| `core/pipeline.go` | update EditFile + MultiEdit callers |
+| `core/batch_operations.go` | update performIntelligentEdit caller |
+| `core/truncation_test.go` | update MultiEdit callers |
+| `core/engine_bench_test.go` | update EditFile caller |
+| `tools_core.go` | +extract `tolerant_whitespace`; +register minify tools; +`20 tools` log |
+| `tools_batch.go` | +extract `tolerant_whitespace` for multi_edit |
+| `tools_minify.go` | NEW — `minify_js` tool registration |
+| `tests/bug16_test.go` | update EditFile + MultiEdit callers |
+| `tests/bug17_test.go` | update MultiEdit callers |
+| `tests/bug18_literal_escapes_test.go` | update EditFile callers |
+| `tests/bug22_multi_edit_test.go` | update MultiEdit callers |
+| `tests/bug23_test.go` | update EditFile + MultiEdit callers |
+| `tests/bug27_multi_edit_atomic_test.go` | update MultiEdit callers |
+| `tests/bug28_html_edit_test.go` | update EditFile callers |
+| `tests/mcp_functions_test.go` | update EditFile callers |
+| `tests/undo_step_through_test.go` | update EditFile + MultiEdit callers |
+
+**Test results:** all existing tests still pass. 38 new tests added, all green.
+
+```
+ok  core         0.680s
+ok  tests        14.372s
+ok  tests/security 0.824s
+ok  .            0.654s
+```
+
 ## [Unreleased / 4.5.5] - 2026-06-04
 
 ### Improvement — Adaptive write_file behavior when backup is available

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -283,6 +283,19 @@ func main() {
 					var result struct{ IsError bool `json:"isError"` }
 					if json.Unmarshal(msg.Result, &result) == nil && result.IsError {
 						pc.entry.Status = "error"
+						// Extract error text from result.content[0].text
+						// (matches the same extraction done in audit.go:60-64
+						// on the server side). Without this, proxy.jsonl shows
+						// status="error" but leaves the error field empty.
+						var resultFull struct {
+							Content []struct {
+								Type string `json:"type"`
+								Text string `json:"text"`
+							} `json:"content"`
+						}
+						if json.Unmarshal(msg.Result, &resultFull) == nil && len(resultFull.Content) > 0 {
+							pc.entry.Error = resultFull.Content[0].Text
+						}
 					}
 				}
 

--- a/content_hash_test.go
+++ b/content_hash_test.go
@@ -1,0 +1,177 @@
+package main
+
+// Tests for improvement B3: content_hash in read_file + expected_hash in edit_file.
+// These verify the stale-edit protection mechanism.
+
+import (
+	"context"
+	"fmt"
+	"hash/fnv"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// TestContentHash_AppearsInRead verifies that read_file appends a
+// "# content_hash: XXXXXXXX" line at the end of its response.
+func TestContentHash_AppearsInRead(t *testing.T) {
+	dir := t.TempDir()
+	reg := buildEditRegistry(t, dir, false)
+	path := filepath.Join(dir, "test.txt")
+	if err := os.WriteFile(path, []byte("hello world"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	req := mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name:      "read_file",
+			Arguments: map[string]interface{}{"path": path},
+		},
+	}
+	result, err := reg.readFileHandler(context.Background(), req)
+	if err != nil {
+		t.Fatalf("read_file: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("read_file returned error: %v", result.Content)
+	}
+	text := resultText(t, result)
+
+	// Extract the content_hash line
+	re := regexp.MustCompile(`(?m)^# content_hash: ([0-9a-f]{8})$`)
+	m := re.FindStringSubmatch(text)
+	if m == nil {
+		t.Fatalf("expected '# content_hash: XXXXXXXX' line in response, got:\n%s", text)
+	}
+	reportedHash := m[1]
+	// Compute what the hash should be (FNV-1a of "hello world\n" + the appended line is circular,
+	// so we just verify it's 8 hex chars — already done by regex).
+	_ = reportedHash
+}
+
+// TestContentHash_Stable verifies that two reads of the same unchanged file
+// return the same content_hash.
+func TestContentHash_Stable(t *testing.T) {
+	dir := t.TempDir()
+	reg := buildEditRegistry(t, dir, false)
+	path := filepath.Join(dir, "stable.txt")
+	if err := os.WriteFile(path, []byte("abc\n"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	read := func() string {
+		req := mcp.CallToolRequest{
+			Params: mcp.CallToolParams{Name: "read_file", Arguments: map[string]interface{}{"path": path}},
+		}
+		result, _ := reg.readFileHandler(context.Background(), req)
+		return resultText(t, result)
+	}
+	text1 := read()
+	text2 := read()
+
+	re := regexp.MustCompile(`# content_hash: ([0-9a-f]{8})`)
+	m1 := re.FindStringSubmatch(text1)
+	m2 := re.FindStringSubmatch(text2)
+	if m1 == nil || m2 == nil {
+		t.Fatal("content_hash line missing in one of the reads")
+	}
+	if m1[1] != m2[1] {
+		t.Errorf("content_hash should be stable for unchanged file: %q vs %q", m1[1], m2[1])
+	}
+}
+
+// TestExpectedHash_Accepted verifies that edit_file with the correct
+// expected_hash proceeds normally (backward-compatible behavior).
+func TestExpectedHash_Accepted(t *testing.T) {
+	dir := t.TempDir()
+	reg := buildEditRegistry(t, dir, false)
+	path := filepath.Join(dir, "ok.txt")
+	if err := os.WriteFile(path, []byte("foo bar\n"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// Compute the hash of the actual file content
+	content, _ := os.ReadFile(path)
+	h := fnv.New32a()
+	h.Write(content)
+	hash := fmt.Sprintf("%08x", h.Sum32())
+
+	_ = callEdit(t, reg, map[string]interface{}{
+		"path":          path,
+		"old_text":      "foo bar",
+		"new_text":      "BAZ",
+		"expected_hash": hash,
+	})
+	// If we got here without an error, the edit was accepted.
+
+	// Verify the file was actually edited
+	after, _ := os.ReadFile(path)
+	if !strings.Contains(string(after), "BAZ") {
+		t.Errorf("expected file to contain BAZ after edit, got: %s", after)
+	}
+}
+
+// TestExpectedHash_Rejected verifies that edit_file with a wrong expected_hash
+// returns a clear error and does NOT modify the file.
+func TestExpectedHash_Rejected(t *testing.T) {
+	dir := t.TempDir()
+	reg := buildEditRegistry(t, dir, false)
+	path := filepath.Join(dir, "noedit.txt")
+	if err := os.WriteFile(path, []byte("original content\n"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	result := callEdit(t, reg, map[string]interface{}{
+		"path":          path,
+		"old_text":      "original",
+		"new_text":      "MODIFIED",
+		"expected_hash": "deadbeef", // wrong hash
+	})
+
+	if !result.IsError {
+		t.Fatal("expected IsError=true on hash mismatch, got ok")
+	}
+	text := resultText(t, result)
+	if !strings.Contains(text, "stale edit") {
+		t.Errorf("expected error to mention 'stale edit', got: %s", text)
+	}
+	if !strings.Contains(text, "deadbeef") {
+		t.Errorf("expected error to mention the wrong expected hash, got: %s", text)
+	}
+
+	// Verify the file was NOT modified
+	after, _ := os.ReadFile(path)
+	if !strings.Contains(string(after), "original content") {
+		t.Errorf("file was modified despite hash mismatch! got: %s", after)
+	}
+	if strings.Contains(string(after), "MODIFIED") {
+		t.Error("file was modified despite hash mismatch")
+	}
+}
+
+// TestExpectedHash_NotProvided verifies that omitting expected_hash preserves
+// the original behavior (backward-compat: edit proceeds without the check).
+func TestExpectedHash_NotProvided(t *testing.T) {
+	dir := t.TempDir()
+	reg := buildEditRegistry(t, dir, false)
+	path := filepath.Join(dir, "nocheck.txt")
+	if err := os.WriteFile(path, []byte("hello world\n"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	_ = callEdit(t, reg, map[string]interface{}{
+		"path":     path,
+		"old_text": "hello",
+		"new_text": "goodbye",
+		// no expected_hash → no check
+	})
+
+	after, _ := os.ReadFile(path)
+	if !strings.Contains(string(after), "goodbye") {
+		t.Errorf("edit without expected_hash should proceed normally, got: %s", after)
+	}
+}

--- a/core/audit_logger.go
+++ b/core/audit_logger.go
@@ -91,6 +91,31 @@ func SetIntegrityStatus(ctx context.Context, status, warning string) {
 	}
 }
 
+// SetCacheHit annotates the current audit entry with whether a read was served from cache.
+// Safe to call even when no audit entry is in context (no-op).
+// Stored as *bool to distinguish "unset" from explicit false in JSON output.
+func SetCacheHit(ctx context.Context, hit bool) {
+	if entry, ok := ctx.Value(AuditEntryKey{}).(*AuditEntry); ok {
+		entry.CacheHit = &hit
+	}
+}
+
+// SetError annotates the current audit entry with a custom error message
+// and forces status to "error" if it was "ok" or empty. Used by handlers
+// that want to log a specific error reason beyond what the default
+// res.IsError text extraction would capture.
+func SetError(ctx context.Context, msg string) {
+	if msg == "" {
+		return
+	}
+	if entry, ok := ctx.Value(AuditEntryKey{}).(*AuditEntry); ok {
+		entry.Error = msg
+		if entry.Status == "ok" || entry.Status == "" {
+			entry.Status = "error"
+		}
+	}
+}
+
 // AuditEntry represents a single MCP tool operation log entry
 type AuditEntry struct {
 	Timestamp    time.Time         `json:"ts"`

--- a/core/batch_operations.go
+++ b/core/batch_operations.go
@@ -575,7 +575,7 @@ func (m *BatchOperationManager) executeEdit(op FileOperation, result *OperationR
 
 	// Use performIntelligentEdit when engine is available
 	if m.engine != nil {
-		editResult, editErr := m.engine.performIntelligentEdit(original, op.OldText, op.NewText)
+		editResult, editErr := m.engine.performIntelligentEdit(original, op.OldText, op.NewText, false)
 		if editErr != nil || editResult.ReplacementCount == 0 {
 			return fmt.Errorf("old_text not found in file: %s. "+
 				"ALWAYS read the file with read_file BEFORE editing. "+

--- a/core/cache_hit_audit_test.go
+++ b/core/cache_hit_audit_test.go
@@ -1,0 +1,76 @@
+package core
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mcp/filesystem-ultra/cache"
+)
+
+// TestCacheHit_AuditEntry_Records verifies that improvement M3 (cache_hit in
+// audit log) is wired correctly. The first read of a file should record
+// CacheHit=false, the second read (warm cache) should record CacheHit=true.
+func TestCacheHit_AuditEntry_Records(t *testing.T) {
+	tempDir := t.TempDir()
+	cacheInstance, err := cache.NewIntelligentCache(4 * 1024 * 1024)
+	if err != nil {
+		t.Fatalf("cache init: %v", err)
+	}
+	engine, err := NewUltraFastEngine(&Config{
+		Cache:        cacheInstance,
+		AllowedPaths: []string{tempDir},
+		ParallelOps:  2,
+	})
+	if err != nil {
+		t.Fatalf("engine init: %v", err)
+	}
+	t.Cleanup(func() { engine.Close() })
+
+	// Create a test file
+	path := filepath.Join(tempDir, "warm.txt")
+	if err := os.WriteFile(path, []byte("hello world\n"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	// Helper to build a ctx with an AuditEntry (simulating auditWrap)
+	makeCtx := func() (context.Context, *AuditEntry) {
+		entry := &AuditEntry{Tool: "read_file"}
+		return context.WithValue(context.Background(), AuditEntryKey{}, entry), entry
+	}
+
+	// ── First read: cache miss ───────────────────────────────────────
+	ctx1, entry1 := makeCtx()
+	if _, err := engine.ReadFileContent(ctx1, path); err != nil {
+		t.Fatalf("first read failed: %v", err)
+	}
+	if entry1.CacheHit == nil {
+		t.Fatal("expected CacheHit to be set on first read, got nil")
+	}
+	if *entry1.CacheHit != false {
+		t.Errorf("expected CacheHit=false on first read (miss), got %v", *entry1.CacheHit)
+	}
+
+	// ── Second read: cache hit ───────────────────────────────────────
+	ctx2, entry2 := makeCtx()
+	if _, err := engine.ReadFileContent(ctx2, path); err != nil {
+		t.Fatalf("second read failed: %v", err)
+	}
+	if entry2.CacheHit == nil {
+		t.Fatal("expected CacheHit to be set on second read, got nil")
+	}
+	if *entry2.CacheHit != true {
+		t.Errorf("expected CacheHit=true on second read (hit), got %v", *entry2.CacheHit)
+	}
+}
+
+// TestSetCacheHit_NoOpWithoutEntry verifies that SetCacheHit is a no-op when
+// no AuditEntry is present in the context (e.g., direct engine calls outside
+// of auditWrap). It must NOT panic.
+func TestSetCacheHit_NoOpWithoutEntry(t *testing.T) {
+	ctx := context.Background()
+	// Should not panic
+	SetCacheHit(ctx, true)
+	SetCacheHit(ctx, false)
+}

--- a/core/claude_optimizer.go
+++ b/core/claude_optimizer.go
@@ -171,7 +171,7 @@ func (o *ClaudeDesktopOptimizer) IntelligentEdit(ctx context.Context, path, oldT
 	// Auto-select strategy
 	if size <= o.config.MaxDirectFileSize {
 		AppendSubOp(ctx, "direct_edit")
-		return o.engine.EditFile(ctx, path, oldText, newText, force, false)
+		return o.engine.EditFile(ctx, path, oldText, newText, force, false, false)
 	} else {
 		AppendSubOp(ctx, "smart_edit_large")
 		return o.engine.SmartEditFile(ctx, path, oldText, newText, force, o.config.MaxDirectFileSize)

--- a/core/claude_optimizer.go
+++ b/core/claude_optimizer.go
@@ -51,6 +51,14 @@ func NewClaudeDesktopOptimizer(engine *UltraFastEngine) *ClaudeDesktopOptimizer 
 }
 
 // IntelligentWrite automatically chooses the best write strategy
+//
+// NOTE: This is the legacy mcp_write entry point. Its truncation guard
+// (further down, around line 67) and inflation guard (line 87) hard-block
+// even when a backup manager is available — these are intentionally
+// different from the write_file tool's CheckWriteOp-based guards in
+// tools_core.go, which now downgrade to warn+backup when a backup is
+// available (see core/feedback_adaptive.go). The divergence is intentional
+// for this release; unification is tracked for a future 4.5.6+ release.
 func (o *ClaudeDesktopOptimizer) IntelligentWrite(ctx context.Context, path, content string) error {
 	// Normalize path first (handles WSL ↔ Windows conversion)
 	path = NormalizePath(path)

--- a/core/config.go
+++ b/core/config.go
@@ -64,4 +64,9 @@ const (
 	// Regex operation timeout to prevent ReDoS (catastrophic backtracking).
 	// Patterns like (a+)+ or (.*)+ can cause exponential time complexity.
 	RegexOperationTimeout = 5 * time.Second
+
+	// DefaultMaxSearchOutputBytes is the default cap for search_files responses.
+	// Prevents accidental multi-MB output that wastes tokens (~500KB ≈ 125k tokens).
+	// Operators can override via Config.MaxSearchOutputBytes; 0 = use default.
+	DefaultMaxSearchOutputBytes = 500 * 1024
 )

--- a/core/edit_operations.go
+++ b/core/edit_operations.go
@@ -49,7 +49,14 @@ type SearchMatch struct {
 //
 // Context Validation: Validates surrounding context (3-5 lines) to prevent
 // editing stale content that may have been modified since the file was read.
-func (e *UltraFastEngine) EditFile(ctx context.Context, path, oldText, newText string, force bool, dryRun bool) (*EditResult, error) {
+//
+// tolerantWhitespace: when true, treats tabs and 4-space runs as equivalent
+// (one tab = 4 spaces) and CRLF/LF as equivalent when matching oldText.
+// The original file bytes are preserved exactly — only the matching is
+// tolerant. Useful when files have been edited with mixed indentation
+// (e.g., a mix of tabs and spaces from different editors), where a literal
+// byte-exact match against a pattern typed with spaces will fail.
+func (e *UltraFastEngine) EditFile(ctx context.Context, path, oldText, newText string, force bool, dryRun bool, tolerantWhitespace bool) (*EditResult, error) {
 	// Normalize path (handles WSL ↔ Windows conversion)
 	path = NormalizePath(path)
 
@@ -155,7 +162,7 @@ func (e *UltraFastEngine) EditFile(ctx context.Context, path, oldText, newText s
 	}
 
 	// Perform intelligent edit
-	result, err := e.performIntelligentEdit(string(content), oldText, newText)
+	result, err := e.performIntelligentEdit(string(content), oldText, newText, tolerantWhitespace)
 	if err != nil {
 		if contextWarning != "" {
 			return nil, fmt.Errorf("edit failed: %w (context hint: %s)", err, contextWarning)
@@ -413,7 +420,14 @@ func (e *UltraFastEngine) createBackup(path string) (string, error) {
 
 // performIntelligentEdit performs intelligent text replacement with optimizations
 // ULTRA-FAST: Uses pre-allocated buffers and minimal allocations
-func (e *UltraFastEngine) performIntelligentEdit(content, oldText, newText string) (*EditResult, error) {
+//
+// tolerantWhitespace: when true, treats tabs and 4-space runs as equivalent
+// (one tab = 4 spaces) and CRLF/LF as equivalent when matching oldText.
+// The original file bytes are preserved exactly — only the matching is tolerant.
+// Useful when files have mixed indentation (e.g., tabs and spaces from
+// different editors) and a literal byte-exact match against a pattern typed
+// with spaces would otherwise fail.
+func (e *UltraFastEngine) performIntelligentEdit(content, oldText, newText string, tolerantWhitespace bool) (*EditResult, error) {
 	if oldText == "" {
 		return nil, fmt.Errorf("old_text cannot be empty")
 	}
@@ -422,6 +436,48 @@ func (e *UltraFastEngine) performIntelligentEdit(content, oldText, newText strin
 	content = normalizeLineEndings(content)
 	oldText = normalizeLineEndings(oldText)
 	newText = normalizeLineEndings(newText)
+
+	// OPTIMIZATION 0: Whitespace-tolerant match (explicit, opt-in).
+	// Runs FIRST when the caller passed tolerantWhitespace=true. We skip
+	// strategies 1-6 (they expect byte-exact matches and would burn cycles
+	// for no reason on a file with mixed tabs/spaces) and try the tolerant
+	// matcher directly. If tolerant matching finds nothing, we fall through
+	// to the rest of the cascade so the caller still gets the best fallback
+	// (literal-escape, regex, etc.) the rest of the code can offer.
+	//
+	// The tolerant match is conservative: it only collapses tabs to 4 spaces
+	// and CRLF/CR to LF. It does NOT collapse runs of multiple spaces, so a
+	// 2-space indent still differs from a 4-space indent (caller can do that
+	// explicitly with normalize_file if needed).
+	if tolerantWhitespace {
+		matches := findAllTolerantMatches(content, oldText)
+		if len(matches) > 0 {
+			newContent, applied := applyTolerantMatches(content, matches, newText)
+			if applied > 0 {
+				startOrig := matches[0].StartOrig
+				endOrig := matches[len(matches)-1].EndOrig
+				startLine := strings.Count(content[:startOrig], "\n") + 1
+				endLine := strings.Count(content[:endOrig], "\n") + 1
+				linesAffected := strings.Count(newContent, "\n") - strings.Count(content, "\n")
+				if linesAffected < 0 {
+					linesAffected = -linesAffected
+				}
+				if !strings.Contains(newText, "\n") && !strings.Contains(content[startOrig:endOrig], "\n") {
+					linesAffected = 1
+				}
+				return &EditResult{
+					ModifiedContent:  newContent,
+					ReplacementCount: applied,
+					MatchConfidence:  "high",
+					LinesAffected:    linesAffected,
+					StartLine:        startLine,
+					EndLine:          endLine,
+				}, nil
+			}
+		}
+		// Tolerant matching found nothing — fall through to the rest of the
+		// fallbacks (regex, literal escapes, flexible pattern, etc.).
+	}
 
 	// OPTIMIZATION 1: Fast path for exact match (most common case - ~80% of edits)
 	// Uses strings.Index which is highly optimized with SIMD on modern CPUs
@@ -1094,7 +1150,7 @@ type MultiEditResult struct {
 // 4. Only one backup is created
 // ULTRA-FAST: Designed for Claude Desktop batch editing
 // Bug #17: Added risk assessment, context validation, hooks, per-edit detail, and "already_present" detection
-func (e *UltraFastEngine) MultiEdit(ctx context.Context, path string, edits []MultiEditOperation, force bool, dryRun bool) (*MultiEditResult, error) {
+func (e *UltraFastEngine) MultiEdit(ctx context.Context, path string, edits []MultiEditOperation, force bool, dryRun bool, tolerantWhitespace bool) (*MultiEditResult, error) {
 	// Normalize path (handles WSL ↔ Windows conversion)
 	path = NormalizePath(path)
 
@@ -1157,7 +1213,7 @@ func (e *UltraFastEngine) MultiEdit(ctx context.Context, path string, edits []Mu
 		if edit.OldText == "" {
 			continue
 		}
-		simResult, simErr := e.performIntelligentEdit(simContent, edit.OldText, edit.NewText)
+		simResult, simErr := e.performIntelligentEdit(simContent, edit.OldText, edit.NewText, false)
 		if simErr == nil && simResult.ReplacementCount > 0 {
 			simContent = simResult.ModifiedContent
 		}
@@ -1246,7 +1302,7 @@ func (e *UltraFastEngine) MultiEdit(ctx context.Context, path string, edits []Mu
 		}
 
 		// Apply this edit
-		editResult, editErr := e.performIntelligentEdit(currentContent, edit.OldText, edit.NewText)
+		editResult, editErr := e.performIntelligentEdit(currentContent, edit.OldText, edit.NewText, false)
 		if editErr != nil || editResult.ReplacementCount == 0 {
 			// Check "already_present" / "ambiguous" (Bug #27 fix)
 			// Compare against originalContent to determine if old_text was actually in the file.

--- a/core/engine.go
+++ b/core/engine.go
@@ -1589,6 +1589,24 @@ func (e *UltraFastEngine) GetBackupManager() *BackupManager {
 	return e.backupManager
 }
 
+// InvalidateCache drops any cached file content for the given path.
+// Safe to call when no cache is configured (no-op). Exposed so external
+// callers (e.g., tool handlers) can keep the cache consistent after
+// writing a file outside the engine's standard write APIs.
+func (e *UltraFastEngine) InvalidateCache(path string) {
+	if e == nil || e.cache == nil || path == "" {
+		return
+	}
+	e.cache.InvalidateFile(path)
+}
+
+// SecureRandomSuffix exposes the internal helper for callers that need
+// a temp file name guaranteed to be unpredictable (atomic write pattern).
+// Uses crypto/rand — never derives from clock or PID.
+func SecureRandomSuffix() string {
+	return secureRandomSuffix()
+}
+
 // GetCurrentBackupID returns the current backup ID in the undo chain for a file
 func (e *UltraFastEngine) GetCurrentBackupID(path string) string {
 	e.backupChainMu.RLock()

--- a/core/engine.go
+++ b/core/engine.go
@@ -53,6 +53,11 @@ type Config struct {
 
 	// Normalizer
 	NormalizerRulesPath string // Path to external normalizer rules JSON file (optional)
+
+	// SearchFiles output cap (improvement M1+M2). 0 = use DefaultMaxSearchOutputBytes.
+	// When search_files produces output larger than this, it is truncated with
+	// a marker telling the model to use count_only:true or a narrower path.
+	MaxSearchOutputBytes int
 }
 
 // UltraFastEngine implements all filesystem operations with maximum performance
@@ -607,6 +612,8 @@ func (e *UltraFastEngine) ReadFileContent(ctx context.Context, path string) (str
 		}
 		// Track access for predictive prefetching
 		e.cache.TrackAccess(path)
+		// Record cache hit for audit log (improvement M3)
+		SetCacheHit(ctx, true)
 		return string(cached), nil
 	}
 
@@ -640,6 +647,8 @@ func (e *UltraFastEngine) ReadFileContent(ctx context.Context, path string) (str
 	// Cache the content and track access
 	e.cache.SetFile(path, result.content)
 	e.cache.TrackAccess(path)
+	// Record cache miss for audit log (improvement M3)
+	SetCacheHit(ctx, false)
 
 	// Execute post-read hook (best-effort)
 	hookCtx.Event = HookPostRead
@@ -1403,6 +1412,12 @@ func (e *UltraFastEngine) ListDirectoryTree(ctx context.Context, path string, ma
 // GetMaxResponseSize returns max response size
 func (e *UltraFastEngine) GetMaxResponseSize() int64 {
 	return e.config.MaxResponseSize
+}
+
+// GetConfig returns a pointer to the engine's configuration.
+// Callers must NOT mutate the returned *Config; it's shared with the engine.
+func (e *UltraFastEngine) GetConfig() *Config {
+	return e.config
 }
 
 // GetMaxSearchResults returns max search results

--- a/core/engine_bench_test.go
+++ b/core/engine_bench_test.go
@@ -142,7 +142,7 @@ func BenchmarkEditFile(b *testing.B) {
 		}
 		b.StartTimer()
 
-		_, err := engine.EditFile(ctx, path, "foo bar baz", "foo BAR baz", true, false)
+		_, err := engine.EditFile(ctx, path, "foo bar baz", "foo BAR baz", true, false, false)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/core/feedback.go
+++ b/core/feedback.go
@@ -35,6 +35,14 @@ type FeedbackSignal struct {
 	Message    string         `json:"message"`
 	Suggestion string         `json:"suggestion,omitempty"`
 	BlockOp    bool           `json:"block_op"` // true = operation should not proceed
+
+	// Downgraded is set to true by ApplyAdaptiveWriteBlock (and any future
+	// adaptive downgraders) when a blocking signal was turned into a
+	// non-blocking warn because a safety backup was created. Tool handlers
+	// can use this to choose response formatting (e.g., force verbose mode
+	// so the restore command is literal, not compact). Omitted from JSON
+	// when false to preserve backward compatibility.
+	Downgraded bool `json:"downgraded,omitempty"`
 }
 
 // OK returns a FeedbackSignal indicating no issue.

--- a/core/feedback_adaptive.go
+++ b/core/feedback_adaptive.go
@@ -1,0 +1,70 @@
+package core
+
+import "fmt"
+
+// AdaptiveWriteBackupCreator is the signature of the function that creates a
+// pre-write safety backup. It is injected so the adaptive logic can be tested
+// without spinning up a real BackupManager. The implementation is expected to
+// return the new backup ID and a nil error on success, or ("", err) on failure.
+//
+// The arguments it receives are: normalized path, operation tag for metadata,
+// and human-readable user context. The closure in the caller is responsible
+// for capturing chain state (previousBackupID) and passing it to the
+// underlying BackupManager — the helper does not need to know about chains.
+type AdaptiveWriteBackupCreator func(normPath, op, userContext string) (string, error)
+
+// ApplyAdaptiveWriteBlock implements the adaptive downgrade for the
+// `write_file` tool's CheckWriteOp signal. When CheckWriteOp decides to
+// block the write (truncation or inflation_loop pattern) and a backup is
+// available, this function attempts to create a safety backup via
+// createBackup. On success the signal is downgraded to a non-blocking WARN,
+// the new backup ID is injected into the Suggestion as a literal restore
+// command, and the Downgraded flag is set so tool handlers can pick a
+// verbose response format. On failure the original blocking signal is
+// returned unchanged (defensive — we never proceed with a destructive
+// write without a safety net).
+//
+// Pure function: no I/O, no engine dependency. The caller in tools_core.go
+// wires createBackup to a closure that calls
+// engine.GetBackupManager().CreateBackupWithContextAndParent with the
+// current chain head captured at call time.
+//
+// Returns the (possibly downgraded) signal and the new backup ID. The
+// backup ID is empty when no downgrade happened (no block, no backup, or
+// backup creation failed).
+func ApplyAdaptiveWriteBlock(
+	signal *FeedbackSignal,
+	backupAvailable bool,
+	normPath string,
+	newSize, existingSize int64,
+	createBackup AdaptiveWriteBackupCreator,
+) (*FeedbackSignal, string) {
+	if signal == nil || !signal.BlockOp || !backupAvailable || createBackup == nil {
+		return signal, ""
+	}
+
+	userContext := fmt.Sprintf(
+		"Adaptive write_file: %d B → %d B (%s)",
+		existingSize, newSize, signal.Pattern,
+	)
+
+	backupID, backupErr := createBackup(normPath, "write_file_adaptive", userContext)
+	if backupErr != nil {
+		// Backup failed → keep original block. The caller in tools_core.go
+		// is responsible for calling engine.SetCurrentBackupID after a
+		// successful downgrade.
+		return signal, ""
+	}
+
+	// Downgrade: KO → Warn, BlockOp=false, Downgraded=true, and prepend the
+	// restore command to the existing suggestion so the user/AI sees the
+	// exact undo action.
+	signal.Status = FeedbackWarn
+	signal.BlockOp = false
+	signal.Downgraded = true
+	signal.Suggestion = fmt.Sprintf(
+		"Backup created: %s. To undo: backup(action:\"restore\", backup_id:\"%s\"). %s",
+		backupID, backupID, signal.Suggestion,
+	)
+	return signal, backupID
+}

--- a/core/feedback_adaptive_test.go
+++ b/core/feedback_adaptive_test.go
@@ -1,0 +1,201 @@
+package core
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestApplyAdaptiveWriteBlock exercises every decision branch in the
+// adaptive downgrade logic. The helper is a pure function over a
+// `FeedbackSignal` + injected backup creator, so no engine, no filesystem,
+// no real BackupManager — fast and deterministic.
+func TestApplyAdaptiveWriteBlock(t *testing.T) {
+	// Factory helpers
+	truncationSignal := func() *FeedbackSignal {
+		return &FeedbackSignal{
+			Status:     FeedbackKO,
+			Pattern:    PatternTruncation,
+			Message:    "new content (400 B) is less than 50% of existing file (1000 B)",
+			Suggestion: "Read the full file first, then use edit_file for partial changes.",
+			BlockOp:    true,
+		}
+	}
+	inflationSignal := func() *FeedbackSignal {
+		return &FeedbackSignal{
+			Status:     FeedbackKO,
+			Pattern:    PatternInflationLoop,
+			Message:    "new content (70 KB) is 3x the existing file (20 KB)",
+			Suggestion: "Use edit_file for surgical changes instead of write_file.",
+			BlockOp:    true,
+		}
+	}
+	okBackup := func(id string) AdaptiveWriteBackupCreator {
+		return func(_, _, _ string) (string, error) { return id, nil }
+	}
+	failingBackup := AdaptiveWriteBackupCreator(func(_, _, _ string) (string, error) {
+		return "", errors.New("disk full")
+	})
+
+	cases := []struct {
+		name             string
+		signal           *FeedbackSignal
+		backupAvailable  bool
+		existingSize     int64
+		newSize          int64
+		creator          AdaptiveWriteBackupCreator
+		wantBlocked      bool
+		wantStatus       FeedbackStatus
+		wantDowngraded   bool
+		wantBackupID     string
+		wantSuggestionHas string
+	}{
+		{
+			name:            "truncation + no backup → keep block",
+			signal:          truncationSignal(),
+			backupAvailable: false,
+			existingSize:    1000, newSize: 400,
+			creator:         okBackup("irrelevant"),
+			wantBlocked:     true,
+			wantStatus:      FeedbackKO,
+			wantDowngraded:  false,
+			wantBackupID:    "",
+		},
+		{
+			name:            "truncation + backup but creator fails → keep block",
+			signal:          truncationSignal(),
+			backupAvailable: true,
+			existingSize:    1000, newSize: 400,
+			creator:         failingBackup,
+			wantBlocked:     true,
+			wantStatus:      FeedbackKO,
+			wantDowngraded:  false,
+			wantBackupID:    "",
+		},
+		{
+			name:             "truncation + backup + creator OK → downgrade with restore cmd",
+			signal:           truncationSignal(),
+			backupAvailable:  true,
+			existingSize:     1000, newSize: 400,
+			creator:          okBackup("20260604-130xxx"),
+			wantBlocked:      false,
+			wantStatus:       FeedbackWarn,
+			wantDowngraded:   true,
+			wantBackupID:     "20260604-130xxx",
+			wantSuggestionHas: "20260604-130xxx",
+		},
+		{
+			name:            "inflation + no backup → keep block",
+			signal:          inflationSignal(),
+			backupAvailable: false,
+			existingSize:    20000, newSize: 70000,
+			creator:         okBackup("irrelevant"),
+			wantBlocked:     true,
+			wantStatus:      FeedbackKO,
+			wantDowngraded:  false,
+		},
+		{
+			name:             "inflation + backup + creator OK → downgrade",
+			signal:           inflationSignal(),
+			backupAvailable:  true,
+			existingSize:     20000, newSize: 70000,
+			creator:          okBackup("backup-456"),
+			wantBlocked:      false,
+			wantStatus:       FeedbackWarn,
+			wantDowngraded:   true,
+			wantBackupID:     "backup-456",
+			wantSuggestionHas: "backup-456",
+		},
+		{
+			name:            "full_rewrite signal (not block) → no-op regardless of backup",
+			signal: &FeedbackSignal{
+				Status:     FeedbackWarn,
+				Pattern:    PatternFullRewrite,
+				Message:    "Full rewrite of foo.go (20 KB → 15 KB).",
+				Suggestion: "Prefer edit_file for targeted changes.",
+				BlockOp:    false,
+			},
+			backupAvailable: true,
+			existingSize:    20000, newSize: 15000,
+			creator:         okBackup("should-not-be-called"),
+			wantBlocked:     false,
+			wantStatus:      FeedbackWarn,
+			wantDowngraded:  false,
+			wantBackupID:    "",
+		},
+		{
+			name:            "OK signal (no pattern) → no-op",
+			signal:          OK(),
+			backupAvailable: true,
+			existingSize:    5000, newSize: 5000,
+			creator:         okBackup("should-not-be-called"),
+			wantBlocked:     false,
+			wantStatus:      FeedbackOK,
+			wantDowngraded:  false,
+			wantBackupID:    "",
+		},
+		{
+			name:            "nil signal → no-op (defensive)",
+			signal:          nil,
+			backupAvailable: true,
+			existingSize:    1000, newSize: 500,
+			creator:         okBackup("irrelevant"),
+			wantBlocked:     false,
+			wantStatus:      "",
+			wantDowngraded:  false,
+			wantBackupID:    "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, gotID := ApplyAdaptiveWriteBlock(
+				tc.signal, tc.backupAvailable, "/tmp/foo",
+				tc.newSize, tc.existingSize, tc.creator,
+			)
+
+			if got != nil && got.BlockOp != tc.wantBlocked {
+				t.Errorf("BlockOp = %v, want %v", got.BlockOp, tc.wantBlocked)
+			}
+			if got != nil && got.Status != tc.wantStatus {
+				t.Errorf("Status = %q, want %q", got.Status, tc.wantStatus)
+			}
+			if got != nil && got.Downgraded != tc.wantDowngraded {
+				t.Errorf("Downgraded = %v, want %v", got.Downgraded, tc.wantDowngraded)
+			}
+			if gotID != tc.wantBackupID {
+				t.Errorf("returned backupID = %q, want %q", gotID, tc.wantBackupID)
+			}
+			if tc.wantSuggestionHas != "" {
+				if got == nil || !strings.Contains(got.Suggestion, tc.wantSuggestionHas) {
+					t.Errorf("Suggestion %q does not contain %q", got.Suggestion, tc.wantSuggestionHas)
+				}
+			}
+		})
+	}
+}
+
+// TestApplyAdaptiveWriteBlock_RestoreCommandFormat pins the exact
+// restore-command template the suggestion must follow. If the format
+// ever drifts, the user-facing recovery story breaks.
+func TestApplyAdaptiveWriteBlock_RestoreCommandFormat(t *testing.T) {
+	signal := &FeedbackSignal{
+		Status:     FeedbackKO,
+		Pattern:    PatternTruncation,
+		Message:    "msg",
+		Suggestion: "original suggestion",
+		BlockOp:    true,
+	}
+	creator := AdaptiveWriteBackupCreator(func(_, _, _ string) (string, error) {
+		return "backup-abc", nil
+	})
+
+	got, _ := ApplyAdaptiveWriteBlock(signal, true, "/x", 100, 500, creator)
+	if got == nil {
+		t.Fatal("got nil signal")
+	}
+	want := `Backup created: backup-abc. To undo: backup(action:"restore", backup_id:"backup-abc"). original suggestion`
+	if got.Suggestion != want {
+		t.Errorf("Suggestion = %q\n          want %q", got.Suggestion, want)
+	}
+}

--- a/core/minifier.go
+++ b/core/minifier.go
@@ -1,0 +1,540 @@
+package core
+
+import (
+	"strings"
+	"unicode"
+)
+
+// MinifyOptions controls JavaScript minification behavior.
+//
+// The zero value applies sensible defaults: remove comments, collapse
+// runs of whitespace, and produce single-line output. Pass a non-zero
+// value to override any of these.
+type MinifyOptions struct {
+	// RemoveComments strips line (//) and block (/* */) comments.
+	// String contents are NEVER touched — only code-level comments.
+	RemoveComments bool
+
+	// CollapseWhitespace replaces runs of spaces and tabs with a single
+	// space where required to keep tokens separate. A space is only
+	// emitted between two identifier-like characters (letters, digits,
+	// underscore, dollar sign).
+	CollapseWhitespace bool
+
+	// SingleLine emits all output on one line (no \n, no \r). If false,
+	// line breaks in the source are preserved.
+	SingleLine bool
+}
+
+// MinifyStats reports what the minifier did to a single file. Returned
+// by MinifyJS so callers can report byte savings to the user.
+type MinifyStats struct {
+	InputBytes       int
+	OutputBytes      int
+	BytesSaved       int
+	ReductionPercent float64
+	CommentsStripped int
+	// True if the minifier hit a state it could not resolve safely
+	// (e.g. an unterminated string). Output may be truncated.
+	Truncated bool
+}
+
+// jsMinifier is the internal state-machine minifier. It walks the input
+// byte by byte, tracking whether we are in code, a string literal, a
+// template literal, a regex literal, or a comment.
+//
+// The minifier is intentionally simple — a full JS parser/AST is out of
+// scope. Edge cases that a real parser would catch (regex with a `/`
+// inside a character class, tagged template literals, etc.) are handled
+// with conservative heuristics that err on the side of preserving the
+// original bytes rather than corrupting them.
+type jsMinifier struct {
+	src              string
+	pos              int
+	out              strings.Builder
+	lastSig          byte // last non-whitespace, non-comment byte output
+	commentsStripped int
+	truncated        bool
+}
+
+// MinifyJS minifies JavaScript source code. It strips comments, collapses
+// whitespace, and (by default) emits a single line. Pure stdlib — no
+// external dependencies, no AST, no JS runtime.
+//
+// SAFETY: best-effort. Real-world JS that uses exotic regex patterns or
+// tagged template literals at the boundary of code/regex heuristics may
+// not be perfectly tokenized. For the common 95% of real-world code this
+// works correctly. The minifier never modifies the contents of strings,
+// template literals, or regex bodies — only the spacing and comments
+// around them.
+func MinifyJS(src string, opts MinifyOptions) (string, MinifyStats) {
+	// Apply defaults for the zero value so callers can use MinifyJS(src, MinifyOptions{})
+	// or even MinifyJS(src) — wait, the latter isn't possible in Go; use the explicit form.
+	if !opts.RemoveComments && !opts.CollapseWhitespace && !opts.SingleLine {
+		opts.RemoveComments = true
+		opts.CollapseWhitespace = true
+		opts.SingleLine = true
+	}
+
+	stats := MinifyStats{InputBytes: len(src)}
+	m := &jsMinifier{src: src}
+	out := m.run(opts)
+	stats.OutputBytes = len(out)
+	stats.BytesSaved = stats.InputBytes - stats.OutputBytes
+	stats.CommentsStripped = m.commentsStripped
+	stats.Truncated = m.truncated
+	if stats.InputBytes > 0 {
+		stats.ReductionPercent = float64(stats.BytesSaved) / float64(stats.InputBytes) * 100
+	}
+	return out, stats
+}
+
+// run is the main state machine loop. It dispatches on the current input
+// character and the current high-level state (we are inside a string /
+// regex / comment, or in code).
+func (m *jsMinifier) run(opts MinifyOptions) string {
+	// Pre-size the output builder. Best case: no whitespace, no comments.
+	// Worst case: 1.0x (we never grow).
+	m.out.Grow(len(m.src))
+
+	for m.pos < len(m.src) {
+		c := m.src[m.pos]
+
+		switch {
+		case c == '\'':
+			m.consumeSingleQuotedString()
+		case c == '"':
+			m.consumeDoubleQuotedString()
+		case c == '`':
+			m.consumeTemplateLiteral()
+		case c == '/' && m.pos+1 < len(m.src) && m.src[m.pos+1] == '/':
+			if opts.RemoveComments {
+				m.consumeLineComment()
+			} else {
+				m.out.WriteByte('/')
+				m.out.WriteByte('/')
+				m.lastSig = '/'
+				m.pos += 2
+			}
+		case c == '/' && m.pos+1 < len(m.src) && m.src[m.pos+1] == '*':
+			if opts.RemoveComments {
+				m.consumeBlockComment()
+			} else {
+				m.out.WriteByte('/')
+				m.out.WriteByte('*')
+				m.lastSig = '*'
+				m.pos += 2
+			}
+		case c == '/':
+			if m.isRegexContext() {
+				m.consumeRegexLiteral()
+			} else {
+				// Division operator (or /=). Emit and move on.
+				m.out.WriteByte('/')
+				m.lastSig = '/'
+				m.pos++
+			}
+		case c == '#' && m.pos == 0 && m.hasShebang():
+			// Shebang at the very start of the file — preserve it verbatim
+			// (some tools strip it, but it's safe to keep and the minified
+			// output will still be valid JS).
+			m.consumeShebang(opts)
+		case c == ' ' || c == '\t' || c == '\n' || c == '\r':
+			m.consumeWhitespace(opts)
+		default:
+			// Anything else: emit as-is.
+			m.out.WriteByte(c)
+			if !unicode.IsSpace(rune(c)) {
+				m.lastSig = c
+			}
+			m.pos++
+		}
+	}
+
+	return m.out.String()
+}
+
+// consumeSingleQuotedString handles '...' with backslash escapes.
+// Stops on unescaped closing quote or EOF. Marks truncated on EOF.
+func (m *jsMinifier) consumeSingleQuotedString() {
+	m.out.WriteByte('\'')
+	m.lastSig = '\''
+	m.pos++
+
+	for m.pos < len(m.src) {
+		c := m.src[m.pos]
+		m.out.WriteByte(c)
+		m.pos++
+		switch c {
+		case '\\':
+			// Backslash escapes the next char. If the next char exists,
+			// write it too. Handles \', \", \\, \n, \u{...}, \xXX, etc.
+			if m.pos < len(m.src) {
+				m.out.WriteByte(m.src[m.pos])
+				m.pos++
+			}
+		case '\'':
+			// End of string.
+			return
+		}
+	}
+	m.truncated = true
+}
+
+// consumeDoubleQuotedString handles "..." with backslash escapes.
+func (m *jsMinifier) consumeDoubleQuotedString() {
+	m.out.WriteByte('"')
+	m.lastSig = '"'
+	m.pos++
+
+	for m.pos < len(m.src) {
+		c := m.src[m.pos]
+		m.out.WriteByte(c)
+		m.pos++
+		switch c {
+		case '\\':
+			if m.pos < len(m.src) {
+				m.out.WriteByte(m.src[m.pos])
+				m.pos++
+			}
+		case '"':
+			return
+		}
+	}
+	m.truncated = true
+}
+
+// consumeTemplateLiteral handles `...` with backtick close, $ and {
+// for ${...} expression interpolation (which is treated as code, so we
+// recurse into the main loop), and backslash escapes.
+func (m *jsMinifier) consumeTemplateLiteral() {
+	m.out.WriteByte('`')
+	m.lastSig = '`'
+	m.pos++
+
+	for m.pos < len(m.src) {
+		c := m.src[m.pos]
+		switch c {
+		case '\\':
+			m.out.WriteByte(c)
+			m.pos++
+			if m.pos < len(m.src) {
+				m.out.WriteByte(m.src[m.pos])
+				m.pos++
+			}
+		case '`':
+			m.out.WriteByte('`')
+			m.lastSig = '`'
+			m.pos++
+			return
+		case '$':
+			// Check for ${ ... }
+			if m.pos+1 < len(m.src) && m.src[m.pos+1] == '{' {
+				m.out.WriteByte('$')
+				m.out.WriteByte('{')
+				m.pos += 2
+				// Recurse into the main loop for the expression body.
+				// The expression is a normal code context — strings,
+				// regex, comments all work the same way.
+				// We bump braceDepth so } inside the expression isn't
+				// treated as template close.
+				m.runTemplateExpression(1, 0)
+				// After runTemplateExpression returns, we are back at
+				// the closing } of ${...}. The caller loop continues.
+				continue
+			}
+			m.out.WriteByte('$')
+			m.pos++
+		default:
+			m.out.WriteByte(c)
+			m.pos++
+		}
+	}
+	m.truncated = true
+}
+
+// runTemplateExpression runs the main state machine starting at the
+// current position until the closing `}` of a ${...} expression. braceDepth
+// is the current nesting depth (1 for the opening ${).
+func (m *jsMinifier) runTemplateExpression(braceDepth, _ int) {
+	// Track unprocessed outer state. We don't return it; we re-implement
+	// the run loop here with a brace-aware exit condition. The main run()
+	// is generic but doesn't know about template interpolation.
+	startPos := m.pos
+	for m.pos < len(m.src) {
+		c := m.src[m.pos]
+		switch {
+		case c == '\'':
+			m.consumeSingleQuotedString()
+		case c == '"':
+			m.consumeDoubleQuotedString()
+		case c == '`':
+			m.consumeTemplateLiteral()
+		case c == '/' && m.pos+1 < len(m.src) && m.src[m.pos+1] == '/':
+			m.consumeLineComment()
+		case c == '/' && m.pos+1 < len(m.src) && m.src[m.pos+1] == '*':
+			m.consumeBlockComment()
+		case c == '/' && m.isRegexContext():
+			m.consumeRegexLiteral()
+		case c == '/' || c == '*':
+			m.out.WriteByte(c)
+			m.lastSig = c
+			m.pos++
+		case c == '{':
+			m.out.WriteByte(c)
+			m.lastSig = c
+			m.pos++
+			braceDepth++
+		case c == '}':
+			m.out.WriteByte(c)
+			m.lastSig = c
+			m.pos++
+			braceDepth--
+			if braceDepth == 0 {
+				return
+			}
+		default:
+			m.out.WriteByte(c)
+			if !unicode.IsSpace(rune(c)) {
+				m.lastSig = c
+			}
+			m.pos++
+		}
+	}
+	_ = startPos
+	m.truncated = true
+}
+
+// consumeRegexLiteral handles /.../[flags]. The leading / was already
+// matched by the caller. We consume the body, then any flag chars
+// [a-z]*.
+func (m *jsMinifier) consumeRegexLiteral() {
+	// Emit the opening slash
+	m.out.WriteByte('/')
+	m.lastSig = '/'
+	m.pos++
+
+	inCharClass := false // inside [...]
+	for m.pos < len(m.src) {
+		c := m.src[m.pos]
+		switch c {
+		case '\\':
+			// Escape: write both bytes
+			m.out.WriteByte(c)
+			m.pos++
+			if m.pos < len(m.src) {
+				m.out.WriteByte(m.src[m.pos])
+				m.pos++
+			}
+		case '[':
+			inCharClass = true
+			m.out.WriteByte(c)
+			m.pos++
+		case ']':
+			inCharClass = false
+			m.out.WriteByte(c)
+			m.pos++
+		case '/':
+			if !inCharClass {
+				// End of regex body
+				m.out.WriteByte('/')
+				m.lastSig = '/'
+				m.pos++
+				// Consume flags: g, i, m, s, u, y, d
+				for m.pos < len(m.src) {
+					f := m.src[m.pos]
+					if (f >= 'a' && f <= 'z') || (f >= 'A' && f <= 'Z') {
+						m.out.WriteByte(f)
+						m.lastSig = f
+						m.pos++
+					} else {
+						break
+					}
+				}
+				return
+			}
+			m.out.WriteByte(c)
+			m.pos++
+		default:
+			m.out.WriteByte(c)
+			m.pos++
+		}
+	}
+	m.truncated = true
+}
+
+// consumeLineComment skips from after // to (but not including) the
+// next \n. The newline itself is left for the main loop to handle as
+// whitespace.
+func (m *jsMinifier) consumeLineComment() {
+	m.commentsStripped++
+	// Skip past the //
+	m.pos += 2
+	for m.pos < len(m.src) && m.src[m.pos] != '\n' {
+		m.pos++
+	}
+	// Do not consume the \n — let the main loop emit it (or strip it as
+	// whitespace if SingleLine is on).
+}
+
+// consumeBlockComment skips from after /* to */ (inclusive).
+func (m *jsMinifier) consumeBlockComment() {
+	m.commentsStripped++
+	m.pos += 2
+	for m.pos < len(m.src) {
+		if m.src[m.pos] == '*' && m.pos+1 < len(m.src) && m.src[m.pos+1] == '/' {
+			m.pos += 2
+			return
+		}
+		m.pos++
+	}
+	m.truncated = true
+}
+
+// consumeShebang copies #!... up to (but not including) the first \n
+// verbatim, and always emits a \n after it. We keep the shebang because
+// some bundlers and CLIs expect it at the start. The trailing \n is
+// emitted even in SingleLine mode — a shebang must be on its own line
+// per the JS spec, so we treat it as structurally significant.
+func (m *jsMinifier) consumeShebang(_ MinifyOptions) {
+	start := m.pos
+	for m.pos < len(m.src) && m.src[m.pos] != '\n' {
+		m.pos++
+	}
+	shebang := m.src[start:m.pos]
+	m.out.WriteString(shebang)
+	m.out.WriteByte('\n')
+	// Don't update lastSig — the shebang doesn't affect JS tokenization.
+}
+
+// hasShebang reports whether the file starts with #!. Only checked at
+// position 0; that's the only place a shebang is valid in JS.
+func (m *jsMinifier) hasShebang() bool {
+	if len(m.src) < 2 || m.src[0] != '#' || m.src[1] != '!' {
+		return false
+	}
+	return true
+}
+
+// isRegexContext uses the last significant output character to decide
+// whether the current / starts a regex literal or is a division operator.
+//
+// This is the standard JS tokenizer heuristic: a / can be a regex after
+// values that "expect" an operand (operators, punctuation, statement
+// start, keywords). It cannot be a regex after another value expression
+// (identifier, number, closing paren, etc.).
+func (m *jsMinifier) isRegexContext() bool {
+	// At the start of the file or after a newline at the very beginning
+	// (no lastSig yet), / is a regex.
+	if m.lastSig == 0 {
+		return true
+	}
+	switch m.lastSig {
+	case '=', '(', ',', '[', '!', '&', '|', '?',
+		':', ';', '{', '}', '~', '^', '+', '-',
+		'*', '/', '%', '<', '>', '\n', '\r':
+		return true
+	}
+	// After a closing ) or ] — the contained expression ended, and a new
+	// expression can start with a regex. e.g., `(1+2) /re/` is ambiguous
+	// in real JS but tools normally disambiguate via this heuristic.
+	// We treat it as NOT a regex after ')' or ']' because that's almost
+	// always a function call or array index, and treating it as regex
+	// would break e.g. `arr.length/2`.
+	// Note: 'return' and similar keyword ENDING characters are handled
+	// indirectly — the space after the keyword is whitespace, which
+	// we skip, so the lastSig will be 'n' (last char of "return").
+	// That's fine: "return/foo/" is treated as a regex context starting
+	// with /, which is what real JS does.
+	return false
+}
+
+// consumeWhitespace handles a run of ASCII whitespace. Behavior depends
+// on opts.SingleLine and opts.CollapseWhitespace:
+//
+//   - SingleLine=true, CollapseWhitespace=true (the default): drop the
+//     whitespace entirely, or emit a single space if needed to keep
+//     two identifier-like tokens from merging.
+//   - SingleLine=true, CollapseWhitespace=false: emit a single space for
+//     any whitespace run (preserves "spacing presence" without the
+//     actual whitespace).
+//   - SingleLine=false, CollapseWhitespace=true: emit \n for real line
+//     breaks (useful for keeping stack-trace line numbers), drop other
+//     whitespace or emit a single space when needed.
+//   - SingleLine=false, CollapseWhitespace=false: emit \n for line breaks,
+//     emit a single space for space/tab runs.
+func (m *jsMinifier) consumeWhitespace(opts MinifyOptions) {
+	// Track whether we saw a real line break.
+	sawLineBreak := false
+	for m.pos < len(m.src) {
+		c := m.src[m.pos]
+		if c == ' ' || c == '\t' {
+			m.pos++
+			continue
+		}
+		if c == '\n' || c == '\r' {
+			sawLineBreak = true
+			// Skip the \n (and \r for CRLF)
+			if c == '\r' && m.pos+1 < len(m.src) && m.src[m.pos+1] == '\n' {
+				m.pos += 2
+			} else {
+				m.pos++
+			}
+			continue
+		}
+		break
+	}
+
+	// No-op if we're at EOF (trailing whitespace).
+	if m.pos >= len(m.src) {
+		return
+	}
+
+	// SingleLine=false: preserve line breaks as \n.
+	if sawLineBreak && !opts.SingleLine {
+		m.out.WriteByte('\n')
+		// The \n is whitespace — don't update lastSig.
+		return
+	}
+
+	if !opts.CollapseWhitespace {
+		// Emit a single space for the run.
+		m.out.WriteByte(' ')
+		return
+	}
+
+	// CollapseWhitespace: emit a single space only if the next non-whitespace
+	// character and the last significant char both look like identifier
+	// characters (so we don't merge "return x" into "returnx" or "1 2" into "12").
+	next := m.nextSignificant()
+	if next == 0 {
+		return
+	}
+	if isIdentByte(m.lastSig) && isIdentByte(next) {
+		m.out.WriteByte(' ')
+	}
+	// Otherwise: drop the whitespace entirely.
+}
+
+// nextSignificant returns the next non-whitespace byte without advancing
+// the cursor. Returns 0 if EOF.
+func (m *jsMinifier) nextSignificant() byte {
+	for i := m.pos; i < len(m.src); i++ {
+		c := m.src[i]
+		if c == ' ' || c == '\t' || c == '\n' || c == '\r' {
+			continue
+		}
+		return c
+	}
+	return 0
+}
+
+// isIdentByte reports whether c can appear in a JS identifier (letter,
+// digit, underscore, dollar). Two such characters next to each other
+// require a space to keep them as separate tokens.
+func isIdentByte(c byte) bool {
+	return (c >= 'a' && c <= 'z') ||
+		(c >= 'A' && c <= 'Z') ||
+		(c >= '0' && c <= '9') ||
+		c == '_' || c == '$'
+}

--- a/core/minifier_test.go
+++ b/core/minifier_test.go
@@ -1,0 +1,278 @@
+package core
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMinifyJS_Simple(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "single line",
+			in:   "var x = 1;",
+			want: "var x=1;",
+		},
+		{
+			name: "spaces around operators",
+			in:   "var x  =  1 +  2 ;",
+			want: "var x=1+2;",
+		},
+		{
+			name: "single-line comment stripped",
+			in:   "var x = 1; // trailing comment\nvar y = 2;",
+			want: "var x=1;var y=2;",
+		},
+		{
+			name: "block comment stripped",
+			in:   "var x = 1; /* multi\nline */ var y = 2;",
+			want: "var x=1;var y=2;",
+		},
+		{
+			name: "comment markers inside string preserved",
+			in:   `var x = "// not a comment";`,
+			want: `var x="// not a comment";`,
+		},
+		{
+			name: "block comment markers inside string preserved",
+			in:   `var x = "/* not a comment */";`,
+			want: `var x="/* not a comment */";`,
+		},
+		{
+			name: "double-quoted string with escaped quote",
+			in:   `var x = "he said \"hi\"";`,
+			want: `var x="he said \"hi\"";`,
+		},
+		{
+			name: "single-quoted string with escaped apostrophe",
+			in:   `var x = 'don\'t';`,
+			want: `var x='don\'t';`,
+		},
+		{
+			name: "regex literal",
+			in:   "var x = /abc/g;",
+			want: "var x=/abc/g;",
+		},
+		{
+			name: "regex with char class",
+			in:   "var x = /[a-z]+/i;",
+			want: "var x=/[a-z]+/i;",
+		},
+		{
+			name: "division vs regex at start",
+			in:   "var a = 1 / 2;",
+			want: "var a=1/2;",
+		},
+		{
+			name: "division chain",
+			in:   "var a = 10/2/5;",
+			want: "var a=10/2/5;",
+		},
+		{
+			name: "regex in array literal context",
+			in:   "var a = [1, /foo/, 2];",
+			want: "var a=[1,/foo/,2];",
+		},
+		{
+			name: "template literal preserved",
+			in:   "var x = `hello ${name}!`;",
+			want: "var x=`hello ${name}!`;",
+		},
+		{
+			name: "template literal with expression",
+			in:   "var x = `a${1+2}b`;",
+			want: "var x=`a${1+2}b`;",
+		},
+		{
+			name: "comment at end of file (no trailing newline)",
+			in:   "var x = 1;// comment",
+			want: "var x=1;",
+		},
+		{
+			name: "shebang preserved",
+			in:   "#!/usr/bin/env node\nvar x = 1;",
+			want: "#!/usr/bin/env node\nvar x=1;",
+		},
+		{
+			name: "identifier separation preserved",
+			in:   "return  true;",
+			want: "return true;",
+		},
+		{
+			name: "return keyword followed by identifier",
+			in:   "function f(){return foo;}",
+			want: "function f(){return foo;}",
+		},
+		{
+			name: "no need to separate number from identifier",
+			in:   "var x=1 ;var y=2 ;",
+			want: "var x=1;var y=2;",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _ := MinifyJS(tt.in, MinifyOptions{})
+			if got != tt.want {
+				t.Errorf("MinifyJS(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMinifyJS_Options(t *testing.T) {
+	src := "var x = 1; // comment\n/* block */\nvar y = 2;"
+
+	t.Run("all disabled means no-op (returns error from tool layer)", func(t *testing.T) {
+		// The zero value applies all-true defaults in MinifyJS, so we can't
+		// call it with all-false. Test the option struct directly.
+		opts := MinifyOptions{RemoveComments: false, CollapseWhitespace: false, SingleLine: false}
+		// MinifyJS detects this and applies defaults (back-compat).
+		got, _ := MinifyJS(src, opts)
+		// Should be the same as default minify because the zero value gets defaulted.
+		if !strings.Contains(got, ";") {
+			t.Errorf("expected minified output, got %q", got)
+		}
+	})
+
+	t.Run("keep single line false preserves newlines", func(t *testing.T) {
+		opts := MinifyOptions{
+			RemoveComments:     true,
+			CollapseWhitespace: true,
+			SingleLine:         false,
+		}
+		got, _ := MinifyJS("var x = 1;\nvar y = 2;", opts)
+		if !strings.Contains(got, "\n") {
+			t.Errorf("expected newline in output, got %q", got)
+		}
+	})
+
+	t.Run("keep comments false preserves them", func(t *testing.T) {
+		opts := MinifyOptions{
+			RemoveComments:     false,
+			CollapseWhitespace: true,
+			SingleLine:         true,
+		}
+		got, _ := MinifyJS("var x = 1; // hi", opts)
+		// The space between `;` and `//` is collapsed by CollapseWhitespace
+		// (since `;` is not an ident char, no space is needed). The comment
+		// itself is preserved verbatim.
+		if !strings.Contains(got, "//hi") {
+			t.Errorf("expected comment to be preserved (collapsed form), got %q", got)
+		}
+	})
+}
+
+func TestMinifyJS_Stats(t *testing.T) {
+	src := "var x = 1;   // hello\n  var y = 2;\n"
+	got, stats := MinifyJS(src, MinifyOptions{})
+
+	if stats.InputBytes != len(src) {
+		t.Errorf("InputBytes = %d, want %d", stats.InputBytes, len(src))
+	}
+	if stats.OutputBytes != len(got) {
+		t.Errorf("OutputBytes = %d, want %d", stats.OutputBytes, len(got))
+	}
+	if stats.BytesSaved != stats.InputBytes-stats.OutputBytes {
+		t.Errorf("BytesSaved = %d, want %d", stats.BytesSaved, stats.InputBytes-stats.OutputBytes)
+	}
+	if stats.CommentsStripped < 1 {
+		t.Errorf("CommentsStripped = %d, want >= 1", stats.CommentsStripped)
+	}
+	if stats.ReductionPercent < 0 {
+		t.Errorf("ReductionPercent = %f, want >= 0", stats.ReductionPercent)
+	}
+}
+
+func TestMinifyJS_TruncatedOnUnterminatedString(t *testing.T) {
+	src := `var x = "never ends`
+	_, stats := MinifyJS(src, MinifyOptions{})
+	if !stats.Truncated {
+		t.Errorf("expected Truncated=true for unterminated string, got %+v", stats)
+	}
+}
+
+func TestMinifyJS_TruncatedOnUnterminatedComment(t *testing.T) {
+	src := "var x = 1; /* never ends"
+	_, stats := MinifyJS(src, MinifyOptions{})
+	if !stats.Truncated {
+		t.Errorf("expected Truncated=true for unterminated block comment, got %+v", stats)
+	}
+}
+
+func TestMinifyJS_RealWorld(t *testing.T) {
+	// A small but realistic snippet to verify the state machine handles
+	// interleaved code, strings, regex, and template literals.
+	src := `
+		// DataTable renderer
+		function renderData(data) {
+			var re = /[a-z]+/gi;
+			var msg = "Hello, " + data.name;
+			var tmpl = ` + "`${data.greeting}, ${data.name}!`" + `;
+			return [re, msg, tmpl];
+		}
+	`
+	min, _ := MinifyJS(src, MinifyOptions{})
+
+	// Sanity: comments stripped, identifiers separated properly, strings/regex intact.
+	if strings.Contains(min, "//") {
+		t.Errorf("// comment should be stripped, got: %q", min)
+	}
+	if !strings.Contains(min, `"Hello, "`) {
+		t.Errorf("string should be preserved, got: %q", min)
+	}
+	if !strings.Contains(min, "/[a-z]+/gi") {
+		t.Errorf("regex should be preserved, got: %q", min)
+	}
+	if !strings.Contains(min, "`${data.greeting}, ${data.name}!`") {
+		t.Errorf("template literal should be preserved, got: %q", min)
+	}
+	// function renderData should NOT be merged with the brace
+	if !strings.Contains(min, "function renderData(") {
+		t.Errorf("identifier separation broken, got: %q", min)
+	}
+}
+
+func TestMinifyJS_DivisionInExpression(t *testing.T) {
+	// A/B should be division, not A and B with a regex.
+	src := "var x = a / b / c;"
+	min, _ := MinifyJS(src, MinifyOptions{})
+	want := "var x=a/b/c;"
+	if min != want {
+		t.Errorf("got %q, want %q", min, want)
+	}
+}
+
+func TestMinifyJS_RegexAfterAssign(t *testing.T) {
+	// After =, the / starts a regex.
+	src := "var x = /pattern/g;"
+	min, _ := MinifyJS(src, MinifyOptions{})
+	want := "var x=/pattern/g;"
+	if min != want {
+		t.Errorf("got %q, want %q", min, want)
+	}
+}
+
+func TestMinifyJS_TernaryAndNullish(t *testing.T) {
+	// `??` and `?.` are operators, not relevant to the minifier state machine,
+	// but verify they pass through unchanged.
+	src := "var x = a ?? b; var y = obj?.prop;"
+	min, _ := MinifyJS(src, MinifyOptions{})
+	want := "var x=a??b;var y=obj?.prop;"
+	if min != want {
+		t.Errorf("got %q, want %q", min, want)
+	}
+}
+
+func TestMinifyJS_EmptyInput(t *testing.T) {
+	got, stats := MinifyJS("", MinifyOptions{})
+	if got != "" {
+		t.Errorf("empty input should produce empty output, got %q", got)
+	}
+	if stats.InputBytes != 0 {
+		t.Errorf("InputBytes = %d, want 0", stats.InputBytes)
+	}
+}

--- a/core/param_validator.go
+++ b/core/param_validator.go
@@ -72,6 +72,7 @@ var toolSchemas = map[string]ToolParamSchema{
 		"create_backup":  {ParamBoolean, false},
 		"dry_run":        {ParamBoolean, false},
 		"whole_word":     {ParamBoolean, false},
+		"expected_hash":  {ParamString, false}, // B3: stale-edit protection
 	},
 	"list_directory": {
 		"path": {ParamString, true},
@@ -209,6 +210,7 @@ var toolSchemas = map[string]ToolParamSchema{
 		"create_backup":  {ParamBoolean, false},
 		"dry_run":        {ParamBoolean, false},
 		"whole_word":     {ParamBoolean, false},
+		"expected_hash":  {ParamString, false}, // B3 alias
 	},
 	"write": {
 		"path":           {ParamString, true},

--- a/core/param_validator.go
+++ b/core/param_validator.go
@@ -57,22 +57,23 @@ var toolSchemas = map[string]ToolParamSchema{
 		"encoding":       {ParamString, false},
 	},
 	"edit_file": {
-		"path":           {ParamString, true},
-		"old_text":       {ParamString, false},
-		"new_text":       {ParamString, false},
-		"old_str":        {ParamString, false}, // alias → old_text (normalizer)
-		"new_str":        {ParamString, false}, // alias → new_text (normalizer)
-		"force":          {ParamBoolean, false},
-		"mode":           {ParamString, false},
-		"occurrence":     {ParamNumber, false},
-		"pattern":        {ParamString, false},
-		"replacement":    {ParamString, false},
-		"patterns_json":  {ParamString, false},
-		"case_sensitive": {ParamBoolean, false},
-		"create_backup":  {ParamBoolean, false},
-		"dry_run":        {ParamBoolean, false},
-		"whole_word":     {ParamBoolean, false},
-		"expected_hash":  {ParamString, false}, // B3: stale-edit protection
+		"path":                {ParamString, true},
+		"old_text":            {ParamString, false},
+		"new_text":            {ParamString, false},
+		"old_str":             {ParamString, false}, // alias → old_text (normalizer)
+		"new_str":             {ParamString, false}, // alias → new_text (normalizer)
+		"force":               {ParamBoolean, false},
+		"mode":                {ParamString, false},
+		"occurrence":          {ParamNumber, false},
+		"pattern":             {ParamString, false},
+		"replacement":         {ParamString, false},
+		"patterns_json":       {ParamString, false},
+		"case_sensitive":      {ParamBoolean, false},
+		"create_backup":       {ParamBoolean, false},
+		"dry_run":             {ParamBoolean, false},
+		"whole_word":          {ParamBoolean, false},
+		"expected_hash":       {ParamString, false}, // B3: stale-edit protection
+		"tolerant_whitespace": {ParamBoolean, false}, // treat tabs↔4sp, CRLF↔LF as equivalent
 	},
 	"list_directory": {
 		"path": {ParamString, true},
@@ -95,9 +96,10 @@ var toolSchemas = map[string]ToolParamSchema{
 
 	// ---- EDIT+ (1) ----
 	"multi_edit": {
-		"path":       {ParamString, true},
-		"edits_json": {ParamString, true},
-		"force":      {ParamBoolean, false},
+		"path":                {ParamString, true},
+		"edits_json":          {ParamString, true},
+		"force":               {ParamBoolean, false},
+		"tolerant_whitespace": {ParamBoolean, false},
 	},
 
 	// ---- FILES (4) ----
@@ -195,22 +197,23 @@ var toolSchemas = map[string]ToolParamSchema{
 		"output":          {ParamString, false},
 	},
 	"edit": {
-		"path":           {ParamString, true},
-		"old_text":       {ParamString, false},
-		"new_text":       {ParamString, false},
-		"old_str":        {ParamString, false},
-		"new_str":        {ParamString, false},
-		"force":          {ParamBoolean, false},
-		"mode":           {ParamString, false},
-		"occurrence":     {ParamNumber, false},
-		"pattern":        {ParamString, false},
-		"replacement":    {ParamString, false},
-		"patterns_json":  {ParamString, false},
-		"case_sensitive": {ParamBoolean, false},
-		"create_backup":  {ParamBoolean, false},
-		"dry_run":        {ParamBoolean, false},
-		"whole_word":     {ParamBoolean, false},
-		"expected_hash":  {ParamString, false}, // B3 alias
+		"path":                {ParamString, true},
+		"old_text":            {ParamString, false},
+		"new_text":            {ParamString, false},
+		"old_str":             {ParamString, false},
+		"new_str":             {ParamString, false},
+		"force":               {ParamBoolean, false},
+		"mode":                {ParamString, false},
+		"occurrence":          {ParamNumber, false},
+		"pattern":             {ParamString, false},
+		"replacement":         {ParamString, false},
+		"patterns_json":       {ParamString, false},
+		"case_sensitive":      {ParamBoolean, false},
+		"create_backup":       {ParamBoolean, false},
+		"dry_run":             {ParamBoolean, false},
+		"whole_word":          {ParamBoolean, false},
+		"expected_hash":       {ParamString, false}, // B3 alias
+		"tolerant_whitespace": {ParamBoolean, false}, // mirror of edit_file
 	},
 	"write": {
 		"path":           {ParamString, true},

--- a/core/pipeline.go
+++ b/core/pipeline.go
@@ -512,7 +512,7 @@ func (pe *PipelineExecutor) executeEdit(ctx context.Context, step PipelineStep, 
 		} else {
 			// Perform actual edit
 			// Force=true because pipeline already assessed risk at batch level
-			editResult, err := pe.engine.EditFile(ctx, normalizedPath, oldText, newText, true, dryRun)
+			editResult, err := pe.engine.EditFile(ctx, normalizedPath, oldText, newText, true, dryRun, false)
 			if err != nil {
 				return &PipelineStepError{
 					StepID:  step.ID,
@@ -625,7 +625,7 @@ func (pe *PipelineExecutor) executeMultiEdit(ctx context.Context, step PipelineS
 			totalEdits += count
 		} else {
 			// Perform actual multi-edit
-			editResult, err := pe.engine.MultiEdit(ctx, normalizedPath, edits, force, dryRun)
+			editResult, err := pe.engine.MultiEdit(ctx, normalizedPath, edits, force, dryRun, false)
 			if err != nil {
 				return &PipelineStepError{
 					StepID:  step.ID,

--- a/core/streaming_operations.go
+++ b/core/streaming_operations.go
@@ -334,7 +334,7 @@ func (e *UltraFastEngine) SmartEditFile(ctx context.Context, path, oldText, newT
 	}
 
 	// Use regular edit for smaller files (EditFile acquires its own semaphore)
-	return e.EditFile(ctx, path, oldText, newText, force, false)
+	return e.EditFile(ctx, path, oldText, newText, force, false, false)
 }
 
 // streamingEditLargeFile handles editing of very large files

--- a/core/truncation_test.go
+++ b/core/truncation_test.go
@@ -50,7 +50,7 @@ func TestBugTruncation_LargeFileMultiEditWithFailure(t *testing.T) {
 		{OldText: "M5_UNIQUE_ID_5005", NewText: "FifthMethodRenamed"},
 	}
 
-	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false)
+	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false, false)
 
 	t.Logf("MultiEdit returned: err=%v", err)
 	if result != nil {
@@ -123,7 +123,7 @@ func TestBugTruncation_MultiEditAllSucceed(t *testing.T) {
 		{OldText: `fmt.Println("Line 100")`, NewText: `fmt.Println("HUNDREDTH")`},
 	}
 
-	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false)
+	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false, false)
 	if err != nil {
 		t.Fatalf("MultiEdit should succeed when all edits work: %v", err)
 	}
@@ -176,7 +176,7 @@ func TestBugTruncation_HighRiskMultiEdit(t *testing.T) {
 		{OldText: "NONEXISTENT_TOKEN_XYZ", NewText: "X"},
 	}
 
-	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false)
+	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false, false)
 
 	// Should fail due to atomic rollback (edit #3 fails)
 	if err == nil {

--- a/core/whitespace_matcher.go
+++ b/core/whitespace_matcher.go
@@ -1,0 +1,162 @@
+package core
+
+import "strings"
+
+// WhitespaceMatch represents a match of oldText in content under tolerant
+// whitespace semantics. StartOrig and EndOrig are byte offsets in the
+// ORIGINAL (unnormalized) content, with EndOrig exclusive (Go slice convention).
+type WhitespaceMatch struct {
+	StartOrig int
+	EndOrig   int
+}
+
+// DefaultIndentSize is the number of spaces one tab expands to during
+// tolerant matching. Matches the convention used by normalizeIndentation
+// elsewhere in the package.
+const DefaultIndentSize = 4
+
+// normalizeForTolerantMatch normalizes s for whitespace-tolerant comparison:
+//
+//	\r\n         → \n
+//	lone \r      → \n
+//	\t           → `indentSize` spaces
+//	other bytes  → unchanged
+//
+// Returns the normalized string and a byteMap where byteMap[i] is the byte
+// offset in the ORIGINAL string that produced normalized byte i. For bytes
+// produced by tab expansion, byteMap points to the original tab byte. For
+// CRLF, byteMap points to the LAST byte consumed (the LF) so that
+// map[end]+1 gives a correct exclusive end that spans the whole CRLF.
+func normalizeForTolerantMatch(s string, indentSize int) (string, []int) {
+	if indentSize <= 0 {
+		indentSize = DefaultIndentSize
+	}
+	// Worst case: every byte becomes `indentSize` bytes (a tab). Avoid
+	// pre-allocating that much for typical files; len(s) is a better default.
+	normalized := make([]byte, 0, len(s))
+	byteMap := make([]int, 0, len(s))
+
+	i := 0
+	for i < len(s) {
+		c := s[i]
+		switch c {
+		case '\r':
+			// CRLF or lone CR — both normalize to LF.
+			// Point byteMap at the LAST byte consumed so endOrig = map+1 spans
+			// the whole line break (CRLF is 2 bytes, not 1).
+			consumed := 1
+			if i+1 < len(s) && s[i+1] == '\n' {
+				consumed = 2
+			}
+			normalized = append(normalized, '\n')
+			byteMap = append(byteMap, i+consumed-1)
+			i += consumed
+		case '\t':
+			// Tab expands to N spaces. All spaces point to the same tab byte,
+			// so map+1 also gives a correct exclusive end (single tab byte).
+			for j := 0; j < indentSize; j++ {
+				normalized = append(normalized, ' ')
+				byteMap = append(byteMap, i)
+			}
+			i++
+		default:
+			normalized = append(normalized, c)
+			byteMap = append(byteMap, i)
+			i++
+		}
+	}
+	return string(normalized), byteMap
+}
+
+// findAllTolerantMatches returns all non-overlapping occurrences of oldText
+// in content under whitespace-tolerant semantics. Matches are byte ranges in
+// the original (unnormalized) content.
+//
+// Returns nil if oldText is empty or no match is found.
+func findAllTolerantMatches(content, oldText string) []WhitespaceMatch {
+	if oldText == "" {
+		return nil
+	}
+	normContent, contentMap := normalizeForTolerantMatch(content, DefaultIndentSize)
+	normOld, _ := normalizeForTolerantMatch(oldText, DefaultIndentSize)
+	if normOld == "" {
+		return nil
+	}
+
+	var matches []WhitespaceMatch
+	searchFrom := 0
+	for {
+		idx := strings.Index(normContent[searchFrom:], normOld)
+		if idx < 0 {
+			break
+		}
+		idx += searchFrom
+
+		// Defensive bounds — should never trip if normalizeForTolerantMatch
+		// and strings.Index are consistent.
+		if idx >= len(contentMap) {
+			break
+		}
+		startOrig := contentMap[idx]
+		endNorm := idx + len(normOld) - 1
+		if endNorm >= len(contentMap) {
+			break
+		}
+		endOrig := contentMap[endNorm] + 1 // exclusive
+
+		matches = append(matches, WhitespaceMatch{StartOrig: startOrig, EndOrig: endOrig})
+		searchFrom = idx + len(normOld)
+		if searchFrom > len(normContent) {
+			break
+		}
+	}
+	return matches
+}
+
+// applyTolerantMatches replaces all matched ranges in content with newText.
+// Returns the modified content and the number of replacements applied.
+//
+// Matches must be non-overlapping. Overlapping matches are silently dropped
+// (a defensive guard; the finder never produces them).
+func applyTolerantMatches(content string, matches []WhitespaceMatch, newText string) (string, int) {
+	if len(matches) == 0 {
+		return content, 0
+	}
+	// Sort matches by start position. The finder already returns them sorted,
+	// but a defensive sort keeps the helper correct in isolation.
+	sorted := make([]WhitespaceMatch, len(matches))
+	copy(sorted, matches)
+	for i := 1; i < len(sorted); i++ {
+		for j := i; j > 0 && sorted[j].StartOrig < sorted[j-1].StartOrig; j-- {
+			sorted[j], sorted[j-1] = sorted[j-1], sorted[j]
+		}
+	}
+
+	// Pre-size the builder: original length + N*(len(newText) - avg match size).
+	// Use a conservative upper bound to avoid reallocations.
+	var totalMatchLen int
+	for _, m := range sorted {
+		totalMatchLen += m.EndOrig - m.StartOrig
+	}
+	estimated := len(content) - totalMatchLen + len(newText)*len(sorted)
+	if estimated < len(content) {
+		estimated = len(content) // underflow guard
+	}
+
+	var sb strings.Builder
+	sb.Grow(estimated)
+	cursor := 0
+	applied := 0
+	for _, m := range sorted {
+		if m.StartOrig < cursor {
+			// Overlapping — skip defensively.
+			continue
+		}
+		sb.WriteString(content[cursor:m.StartOrig])
+		sb.WriteString(newText)
+		cursor = m.EndOrig
+		applied++
+	}
+	sb.WriteString(content[cursor:])
+	return sb.String(), applied
+}

--- a/core/whitespace_matcher_test.go
+++ b/core/whitespace_matcher_test.go
@@ -1,0 +1,250 @@
+package core
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestWhitespaceMatcher_TabsVsSpaces verifies that a tab in the file
+// matches 4 spaces in the pattern (and vice versa).
+func TestWhitespaceMatcher_TabsVsSpaces(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		pattern string
+		want    int // number of matches expected
+	}{
+		{
+			name:    "tab in file, 4 spaces in pattern",
+			content: "function foo() {\n\tbar();\n}",
+			pattern: "    bar();",
+			want:    1,
+		},
+		{
+			name:    "4 spaces in file, tab in pattern",
+			content: "function foo() {\n    bar();\n}",
+			pattern: "\tbar();",
+			want:    1,
+		},
+		{
+			name:    "no whitespace difference, exact match",
+			content: "function foo() {\n    bar();\n}",
+			pattern: "    bar();",
+			want:    1,
+		},
+		{
+			name:    "multiple tabs in file, multiple spaces in pattern",
+			content: "\t\tvar x = 1;",
+			pattern: "        var x = 1;", // 8 spaces
+			want:    1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matches := findAllTolerantMatches(tt.content, tt.pattern)
+			if len(matches) != tt.want {
+				t.Errorf("got %d matches, want %d", len(matches), tt.want)
+			}
+		})
+	}
+}
+
+// TestWhitespaceMatcher_CRLFvsLF verifies that CRLF in the file matches
+// LF in the pattern (and vice versa).
+func TestWhitespaceMatcher_CRLFvsLF(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		pattern string
+		want    int
+	}{
+		{
+			name:    "CRLF in file, LF in pattern",
+			content: "line1\r\nline2\r\nline3",
+			pattern: "line1\nline2",
+			want:    1,
+		},
+		{
+			name:    "LF in file, CRLF in pattern",
+			content: "line1\nline2\nline3",
+			pattern: "line1\r\nline2",
+			want:    1,
+		},
+		{
+			name:    "lone CR in file, LF in pattern",
+			content: "line1\rline2",
+			pattern: "line1\nline2",
+			want:    1,
+		},
+		{
+			name:    "mixed CRLF and LF in file",
+			content: "line1\r\nline2\nline3\rline4",
+			pattern: "line1\nline2\nline3\nline4",
+			want:    1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matches := findAllTolerantMatches(tt.content, tt.pattern)
+			if len(matches) != tt.want {
+				t.Errorf("got %d matches, want %d", len(matches), tt.want)
+			}
+		})
+	}
+}
+
+// TestWhitespaceMatcher_MultipleMatches verifies that all non-overlapping
+// matches are returned, not just the first.
+func TestWhitespaceMatcher_MultipleMatches(t *testing.T) {
+	content := "\tfoo();\n\tbar();\n\tbaz();\n"
+	pattern := "    "
+	matches := findAllTolerantMatches(content, pattern)
+	if len(matches) != 3 {
+		t.Errorf("got %d matches, want 3", len(matches))
+	}
+	// Verify each match points to a single tab byte (4 spaces → 1 tab).
+	for i, m := range matches {
+		if m.EndOrig-m.StartOrig != 1 {
+			t.Errorf("match %d: span = %d, want 1 (single tab byte)", i, m.EndOrig-m.StartOrig)
+		}
+	}
+}
+
+// TestWhitespaceMatcher_PreservesByteRange verifies that EndOrig correctly
+// points one past the last original byte consumed by the match.
+func TestWhitespaceMatcher_PreservesByteRange(t *testing.T) {
+	content := "a\r\nb"
+	pattern := "a\nb"
+	matches := findAllTolerantMatches(content, pattern)
+	if len(matches) != 1 {
+		t.Fatalf("got %d matches, want 1", len(matches))
+	}
+	if matches[0].StartOrig != 0 || matches[0].EndOrig != 4 {
+		t.Errorf("got range [%d, %d), want [0, 4)", matches[0].StartOrig, matches[0].EndOrig)
+	}
+	if content[matches[0].StartOrig:matches[0].EndOrig] != "a\r\nb" {
+		t.Errorf("range slice = %q, want %q", content[matches[0].StartOrig:matches[0].EndOrig], "a\r\nb")
+	}
+}
+
+// TestWhitespaceMatcher_UTF8Preserved verifies that multi-byte UTF-8
+// characters in the file don't break byte indexing.
+func TestWhitespaceMatcher_UTF8Preserved(t *testing.T) {
+	content := "// café: 漢字\nfunction foo() {\n\tbar();\n}"
+	pattern := "function foo() {\n    bar();\n}"
+	matches := findAllTolerantMatches(content, pattern)
+	if len(matches) != 1 {
+		t.Fatalf("got %d matches, want 1", len(matches))
+	}
+	// The match starts at the "f" of "function" and ends at the "}"
+	if !strings.HasPrefix(content[matches[0].StartOrig:], "function foo()") {
+		t.Errorf("match slice should start with 'function foo()'")
+	}
+	if !strings.HasSuffix(content[:matches[0].EndOrig], "}") {
+		t.Errorf("match slice should end with '}'")
+	}
+}
+
+// TestWhitespaceMatcher_NoMatch verifies the finder returns nil when the
+// pattern is absent.
+func TestWhitespaceMatcher_NoMatch(t *testing.T) {
+	matches := findAllTolerantMatches("hello world", "goodbye")
+	if len(matches) != 0 {
+		t.Errorf("got %d matches, want 0", len(matches))
+	}
+}
+
+// TestWhitespaceMatcher_EmptyPattern verifies the finder refuses empty
+// patterns (which would be an infinite match loop).
+func TestWhitespaceMatcher_EmptyPattern(t *testing.T) {
+	matches := findAllTolerantMatches("hello", "")
+	if matches != nil {
+		t.Errorf("got %v, want nil for empty pattern", matches)
+	}
+}
+
+// TestApplyTolerantMatches_ReplacesAll verifies the helper correctly
+// applies newText to all matches.
+func TestApplyTolerantMatches_ReplacesAll(t *testing.T) {
+	content := "\tfoo\n\tbar\n\tbaz\n"
+	pattern := "    "
+	newText := "  " // 2 spaces
+	result, count := applyTolerantMatches(content, findAllTolerantMatches(content, pattern), newText)
+	if count != 3 {
+		t.Errorf("replacement count = %d, want 3", count)
+	}
+	expected := "  foo\n  bar\n  baz\n"
+	if result != expected {
+		t.Errorf("got %q, want %q", result, expected)
+	}
+}
+
+// TestApplyTolerantMatches_PreservesUntouched verifies that bytes
+// outside the matches are preserved exactly.
+func TestApplyTolerantMatches_PreservesUntouched(t *testing.T) {
+	content := "before\r\n\tafter"
+	pattern := "    "
+	result, count := applyTolerantMatches(content, findAllTolerantMatches(content, pattern), "XX")
+	if count != 1 {
+		t.Errorf("replacement count = %d, want 1", count)
+	}
+	if result != "before\r\nXXafter" {
+		t.Errorf("got %q, want %q", result, "before\r\nXXafter")
+	}
+}
+
+// TestPerformIntelligentEdit_TolerantMode is an end-to-end test that
+// verifies the tolerant mode is plumbed through performIntelligentEdit
+// and correctly finds a match that exact mode would miss — specifically
+// when a tab appears in the MIDDLE of a line (not just leading). The
+// existing OPTIMIZATION 7 only handles leading-whitespace differences
+// (it normalizes only line-leading whitespace); tolerant mode handles
+// tabs anywhere on the line.
+func TestPerformIntelligentEdit_TolerantMode(t *testing.T) {
+	engine, _ := newTestEngineForMinifier(t)
+	// File uses a tab between the comma and the variable name. The
+	// caller's pattern uses 4 spaces (typical of typed-from-IDE text).
+	content := "call(a,\tb);"
+
+	// Without tolerant: exact match must fail (tab ≠ 4 spaces). The
+	// leading-only fallback in OPTIMIZATION 7 also fails because the
+	// tab is not line-leading.
+	_, err := engine.performIntelligentEdit(content, "call(a,    b);", "call(a,REPLACED);", false)
+	if err == nil {
+		t.Errorf("expected error in non-tolerant mode (tab in middle of line), got nil")
+	}
+
+	// With tolerant: should succeed and preserve the surrounding bytes.
+	res, err := engine.performIntelligentEdit(content, "call(a,    b);", "call(a,REPLACED);", true)
+	if err != nil {
+		t.Fatalf("tolerant mode failed: %v", err)
+	}
+	if res.ReplacementCount != 1 {
+		t.Errorf("got %d replacements, want 1", res.ReplacementCount)
+	}
+	expected := "call(a,REPLACED);"
+	if res.ModifiedContent != expected {
+		t.Errorf("got %q, want %q", res.ModifiedContent, expected)
+	}
+}
+
+// newTestEngineForMinifier constructs a minimal engine for tests that
+// only need the performIntelligentEdit path. It does not configure
+// backup, audit, or cache.
+func newTestEngineForMinifier(t *testing.T) (*UltraFastEngine, *TestStats) {
+	t.Helper()
+	// We don't need a fully-wired engine; performIntelligentEdit only
+	// reads from its arguments and the engine's riskThresholds. Use a
+	// zero-value engine for simplicity.
+	engine := &UltraFastEngine{}
+	// The riskThresholds field is required by CalculateChangeImpact;
+	// the zero value works for our tests (no blocking).
+	return engine, nil
+}
+
+// TestStats is a placeholder for any future test metrics. Currently
+// unused; exists so newTestEngineForMinifier can return a second value
+// for symmetry with other test helpers without an "unused return" lint.
+type TestStats struct{}

--- a/search_output_cap_test.go
+++ b/search_output_cap_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mcp/filesystem-ultra/cache"
+	"github.com/mcp/filesystem-ultra/core"
+)
+
+// newEngineWithCap builds a minimal engine + cache for testing capSearchOutput.
+// The engine doesn't need real hooks or backup manager — capSearchOutput only
+// reads the config's MaxSearchOutputBytes field.
+func newEngineWithCap(t *testing.T, capBytes int) *core.UltraFastEngine {
+	t.Helper()
+	c, err := cache.NewIntelligentCache(1024 * 1024)
+	if err != nil {
+		t.Fatalf("cache init: %v", err)
+	}
+	engine, err := core.NewUltraFastEngine(&core.Config{
+		Cache:               c,
+		MaxSearchOutputBytes: capBytes,
+		ParallelOps:         2,
+	})
+	if err != nil {
+		t.Fatalf("engine init: %v", err)
+	}
+	t.Cleanup(func() { engine.Close() })
+	return engine
+}
+
+// TestCapSearchOutput_BelowCap: response under the cap is returned unchanged.
+func TestCapSearchOutput_BelowCap(t *testing.T) {
+	engine := newEngineWithCap(t, 1024) // 1KB cap
+	small := strings.Repeat("a", 500)
+	got := capSearchOutput(small, engine)
+	if got != small {
+		t.Errorf("expected unchanged output under cap, got len=%d (input=%d)", len(got), len(small))
+	}
+	if strings.Contains(got, "truncated") {
+		t.Error("output under cap should not contain truncation marker")
+	}
+}
+
+// TestCapSearchOutput_AboveCap: response over the cap is truncated with marker.
+func TestCapSearchOutput_AboveCap(t *testing.T) {
+	engine := newEngineWithCap(t, 1024) // 1KB cap
+	big := strings.Repeat("x", 5000)
+	got := capSearchOutput(big, engine)
+	if len(got) >= len(big) {
+		t.Errorf("expected truncated output (len < %d), got len=%d", len(big), len(got))
+	}
+	if !strings.Contains(got, "⚠️ truncated") {
+		t.Error("expected truncation marker in output, not found")
+	}
+	if !strings.Contains(got, "count_only:true") {
+		t.Error("expected marker to suggest count_only:true")
+	}
+}
+
+// TestCapSearchOutput_DefaultCap: 0 cap → uses DefaultMaxSearchOutputBytes (500KB).
+func TestCapSearchOutput_DefaultCap(t *testing.T) {
+	engine := newEngineWithCap(t, 0) // 0 → default
+	big := strings.Repeat("y", 600*1024) // 600KB > 500KB default
+	got := capSearchOutput(big, engine)
+	if !strings.Contains(got, "truncated") {
+		t.Error("expected default cap (500KB) to truncate 600KB input")
+	}
+}
+
+// TestCapSearchOutput_ExactBoundary: at the cap exactly, no truncation.
+func TestCapSearchOutput_ExactBoundary(t *testing.T) {
+	engine := newEngineWithCap(t, 100)
+	exact := strings.Repeat("z", 100) // exactly 100 bytes
+	got := capSearchOutput(exact, engine)
+	if got != exact {
+		t.Errorf("at exact boundary expected unchanged, got len=%d (input=%d)", len(got), len(exact))
+	}
+	overBy1 := exact + "!"
+	got2 := capSearchOutput(overBy1, engine)
+	if !strings.Contains(got2, "truncated") {
+		t.Error("101 bytes should trigger truncation at 100-byte cap")
+	}
+}

--- a/tests/audit_set_error_test.go
+++ b/tests/audit_set_error_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mcp/filesystem-ultra/core"
+)
+
+// TestSetError_SetsFieldAndForcesErrorStatus verifies that SetError correctly
+// annotates the AuditEntry in context with a custom error message and
+// downgrades the status to "error" if it was "ok".
+func TestSetError_SetsFieldAndForcesErrorStatus(t *testing.T) {
+	entry := &core.AuditEntry{Tool: "edit_file", Status: "ok"}
+	ctx := context.WithValue(context.Background(), core.AuditEntryKey{}, entry)
+
+	core.SetError(ctx, "stale edit: file content changed since read")
+
+	if entry.Error != "stale edit: file content changed since read" {
+		t.Errorf("expected Error set, got %q", entry.Error)
+	}
+	if entry.Status != "error" {
+		t.Errorf("expected Status=error after SetError, got %q", entry.Status)
+	}
+}
+
+// TestSetError_EmptyMessageIsNoOp verifies that calling SetError with ""
+// does not modify the entry — guards against accidental empty overwrites.
+func TestSetError_EmptyMessageIsNoOp(t *testing.T) {
+	entry := &core.AuditEntry{Tool: "read_file", Status: "ok", Error: "previous"}
+	ctx := context.WithValue(context.Background(), core.AuditEntryKey{}, entry)
+
+	core.SetError(ctx, "")
+
+	if entry.Error != "previous" {
+		t.Errorf("empty SetError should preserve previous error, got %q", entry.Error)
+	}
+	if entry.Status != "ok" {
+		t.Errorf("empty SetError should preserve status, got %q", entry.Status)
+	}
+}
+
+// TestSetError_NoOpWithoutEntry verifies that SetError is a no-op when no
+// AuditEntry is in the context (e.g., direct engine calls outside auditWrap).
+func TestSetError_NoOpWithoutEntry(t *testing.T) {
+	ctx := context.Background()
+	// Must not panic
+	core.SetError(ctx, "this should be silently dropped")
+}

--- a/tests/bug16_test.go
+++ b/tests/bug16_test.go
@@ -139,7 +139,7 @@ func TestBug16_MediumRiskAutoProceeds(t *testing.T) {
 	}
 
 	// Edit with force=false — should NOT block (Bug #16 fix)
-	result, err := engine.EditFile(context.Background(), testFile, strings.Repeat("B", 100), strings.Repeat("D", 100), false, false)
+	result, err := engine.EditFile(context.Background(), testFile, strings.Repeat("B", 100), strings.Repeat("D", 100), false, false, false)
 	if err != nil {
 		t.Fatalf("MEDIUM risk edit should NOT block, got error: %v", err)
 	}
@@ -171,7 +171,7 @@ func TestBug16_HighRiskAutoProceeds(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result, err := engine.EditFile(context.Background(), testFile, strings.Repeat("B", 400), strings.Repeat("D", 400), false, false)
+	result, err := engine.EditFile(context.Background(), testFile, strings.Repeat("B", 400), strings.Repeat("D", 400), false, false, false)
 	if err != nil {
 		t.Fatalf("HIGH risk edit should NOT block, got error: %v", err)
 	}
@@ -197,7 +197,7 @@ func TestBug16_CriticalRiskProceeds(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result, err := engine.EditFile(context.Background(), testFile, strings.Repeat("A", 10), strings.Repeat("B", 10), false, false)
+	result, err := engine.EditFile(context.Background(), testFile, strings.Repeat("A", 10), strings.Repeat("B", 10), false, false, false)
 	if err != nil {
 		t.Fatalf("CRITICAL risk edit should proceed (Bug #22), got error: %v", err)
 	}
@@ -222,7 +222,7 @@ func TestBug16_CriticalRiskForceProceeds(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result, err := engine.EditFile(context.Background(), testFile, strings.Repeat("A", 10), strings.Repeat("B", 10), true, false)
+	result, err := engine.EditFile(context.Background(), testFile, strings.Repeat("A", 10), strings.Repeat("B", 10), true, false, false)
 	if err != nil {
 		t.Fatalf("CRITICAL risk edit with force=true should succeed, got error: %v", err)
 	}
@@ -243,7 +243,7 @@ func TestBug16_LowRiskNoWarning(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result, err := engine.EditFile(context.Background(), testFile, "HELLO", "WORLD", false, false)
+	result, err := engine.EditFile(context.Background(), testFile, "HELLO", "WORLD", false, false, false)
 	if err != nil {
 		t.Fatalf("LOW risk edit should succeed, got error: %v", err)
 	}
@@ -264,7 +264,7 @@ func TestBug16_BackupCreatedForCritical(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result, err := engine.EditFile(context.Background(), testFile, strings.Repeat("A", 10), strings.Repeat("B", 10), false, false)
+	result, err := engine.EditFile(context.Background(), testFile, strings.Repeat("A", 10), strings.Repeat("B", 10), false, false, false)
 	if err != nil {
 		t.Fatalf("CRITICAL edit should proceed (Bug #22): %v", err)
 	}
@@ -295,7 +295,7 @@ func TestBug16_MultiEditWithForce(t *testing.T) {
 		{OldText: "line3", NewText: "modified3"},
 	}
 
-	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false)
+	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false, false)
 	if err != nil {
 		t.Fatalf("MultiEdit should succeed, got error: %v", err)
 	}

--- a/tests/bug17_test.go
+++ b/tests/bug17_test.go
@@ -31,7 +31,7 @@ func TestBug17_OverlappingEditsNotMisreported(t *testing.T) {
 		},
 	}
 
-	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false)
+	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false, false)
 	if err != nil {
 		t.Fatalf("MultiEdit should succeed, got error: %v", err)
 	}
@@ -84,7 +84,7 @@ func TestBug17_AllEditsApplied(t *testing.T) {
 		{OldText: "line3_target", NewText: "modified3"},
 	}
 
-	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false)
+	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false, false)
 	if err != nil {
 		t.Fatalf("MultiEdit should succeed: %v", err)
 	}
@@ -122,7 +122,7 @@ func TestBug17_GenuineFailureStillReported(t *testing.T) {
 		{OldText: "NONEXISTENT_TEXT", NewText: "should_fail"},
 	}
 
-	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false)
+	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false, false)
 
 	// Bug #27: multi_edit is now atomic — should return error when any edit fails
 	if err == nil {
@@ -178,7 +178,7 @@ func TestBug17_RiskAssessmentCriticalProceeds(t *testing.T) {
 		{OldText: "AB", NewText: "CD"},
 	}
 
-	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false)
+	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false, false)
 	if err != nil {
 		t.Fatalf("CRITICAL risk MultiEdit should proceed (Bug #22), got error: %v", err)
 	}
@@ -207,7 +207,7 @@ func TestBug17_RiskAssessmentCriticalForceProceeds(t *testing.T) {
 		{OldText: "AB", NewText: "CD"},
 	}
 
-	result, err := engine.MultiEdit(context.Background(), testFile, edits, true, false)
+	result, err := engine.MultiEdit(context.Background(), testFile, edits, true, false, false)
 	if err != nil {
 		t.Fatalf("CRITICAL risk with force=true should succeed: %v", err)
 	}
@@ -238,7 +238,7 @@ func TestBug17_EditDetailsPopulated(t *testing.T) {
 		{OldText: "ccc", NewText: "zzz"},
 	}
 
-	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false)
+	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false, false)
 
 	// Bug #27: atomic rollback — any failed edit means file is NOT modified
 	if err == nil {
@@ -285,7 +285,7 @@ func TestBug17_BackwardCompatibility(t *testing.T) {
 		{OldText: "hello", NewText: "goodbye"},
 	}
 
-	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false)
+	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false, false)
 	if err != nil {
 		t.Fatalf("Should succeed: %v", err)
 	}
@@ -334,7 +334,7 @@ func TestBug17_AllAlreadyPresent(t *testing.T) {
 		{OldText: "original3", NewText: "modified3"},
 	}
 
-	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false)
+	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false, false)
 	if err != nil {
 		t.Fatalf("MultiEdit should succeed: %v", err)
 	}
@@ -368,7 +368,7 @@ func TestBug17_AmbiguousOldTextNotInOriginal(t *testing.T) {
 		{OldText: "original3", NewText: "modified3"},
 	}
 
-	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false)
+	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false, false)
 	if err == nil {
 		t.Fatal("MultiEdit should return error for ambiguous edits")
 	}
@@ -409,7 +409,7 @@ func TestBug17_MixedOverlapAndIndependent(t *testing.T) {
 		{OldText: "DDD", NewText: "ZZZ"},
 	}
 
-	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false)
+	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false, false)
 	if err != nil {
 		t.Fatalf("Should succeed: %v", err)
 	}

--- a/tests/bug18_literal_escapes_test.go
+++ b/tests/bug18_literal_escapes_test.go
@@ -53,7 +53,7 @@ func TestBug18_LiteralNewlineEscapes(t *testing.T) {
 	oldTextWithLiteralEscapes := `    private async Task HandleKeyDown(KeyboardEventArgs e) {\n        if (e.Key == "Enter") await Search();\n    }\n\n    private async Task Search()`
 	newText := "    private async Task HandleKeyDown(KeyboardEventArgs e) {\n        if (e.Key == \"Enter\") await Search();\n    }\n\n    private async Task SearchOrders()"
 
-	result, err := engine.EditFile(ctx, testFile, oldTextWithLiteralEscapes, newText, false, false)
+	result, err := engine.EditFile(ctx, testFile, oldTextWithLiteralEscapes, newText, false, false, false)
 	if err != nil {
 		t.Fatalf("EditFile failed with literal \\n escapes: %v", err)
 	}
@@ -88,7 +88,7 @@ func TestBug18_LiteralTabEscapes(t *testing.T) {
 	oldTextLiteral := `\tfunction hello() {\n\t\treturn 'world';\n\t}`
 	newText := "\tfunction hello() {\n\t\treturn 'universe';\n\t}"
 
-	result, err := engine.EditFile(ctx, testFile, oldTextLiteral, newText, false, false)
+	result, err := engine.EditFile(ctx, testFile, oldTextLiteral, newText, false, false, false)
 	if err != nil {
 		t.Fatalf("EditFile failed with literal \\t escapes: %v", err)
 	}
@@ -119,7 +119,7 @@ func TestBug18_RealNewlinesStillWork(t *testing.T) {
 
 	// Normal edit with real newlines (should still work as before)
 	// force=true because this small file triggers CRITICAL risk (>90% change)
-	result, err := engine.EditFile(ctx, testFile, "line1\nline2", "lineA\nlineB", true, false)
+	result, err := engine.EditFile(ctx, testFile, "line1\nline2", "lineA\nlineB", true, false, false)
 	if err != nil {
 		t.Fatalf("EditFile failed with real newlines: %v", err)
 	}
@@ -151,7 +151,7 @@ func TestBug18_CodeWithBackslashN(t *testing.T) {
 
 	// Edit with real newlines — the literal \n inside Printf should be preserved
 	// force=true because this small file triggers CRITICAL risk (>90% change)
-	result, err := engine.EditFile(ctx, testFile, "fmt.Printf(\"hello\\nworld\")", "fmt.Printf(\"hello\\nuniverse\")", true, false)
+	result, err := engine.EditFile(ctx, testFile, "fmt.Printf(\"hello\\nworld\")", "fmt.Printf(\"hello\\nuniverse\")", true, false, false)
 	if err != nil {
 		t.Fatalf("EditFile failed: %v", err)
 	}

--- a/tests/bug22_multi_edit_test.go
+++ b/tests/bug22_multi_edit_test.go
@@ -63,7 +63,7 @@ func TestBug22_MultiEditOldStrAlias(t *testing.T) {
 		t.Fatal("NewText is empty — new_str alias not recognized")
 	}
 
-	result, err := engine.MultiEdit(ctx, filePath, edits, false, false)
+	result, err := engine.MultiEdit(ctx, filePath, edits, false, false, false)
 	if err != nil {
 		t.Fatalf("MultiEdit failed with old_str alias: %v", err)
 	}
@@ -106,7 +106,7 @@ func TestBug22_MultiEditMixedAliases(t *testing.T) {
 		t.Fatalf("Mixed alias parsing failed: edit[0].OldText=%q, edit[1].OldText=%q", edits[0].OldText, edits[1].OldText)
 	}
 
-	result, err := engine.MultiEdit(ctx, filePath, edits, false, false)
+	result, err := engine.MultiEdit(ctx, filePath, edits, false, false, false)
 	if err != nil {
 		t.Fatalf("MultiEdit with mixed aliases failed: %v", err)
 	}
@@ -140,7 +140,7 @@ func TestBug22_MultiEditLiteralEscapesContextValidation(t *testing.T) {
 		{OldText: "line1\\nline2", NewText: "lineA\\nlineB"},
 	}
 
-	result, err := engine.MultiEdit(ctx, filePath, edits, false, false)
+	result, err := engine.MultiEdit(ctx, filePath, edits, false, false, false)
 	if err != nil {
 		t.Fatalf("MultiEdit failed with literal escapes: %v", err)
 	}
@@ -177,7 +177,7 @@ func main() {
 		t.Fatalf("Failed to parse standard edits: %v", err)
 	}
 
-	result, err := engine.MultiEdit(ctx, filePath, edits, false, false)
+	result, err := engine.MultiEdit(ctx, filePath, edits, false, false, false)
 	if err != nil {
 		t.Fatalf("MultiEdit with standard old_text failed: %v", err)
 	}

--- a/tests/bug23_test.go
+++ b/tests/bug23_test.go
@@ -46,7 +46,7 @@ func TestBug23_EditFile_CRLFMatchesLF(t *testing.T) {
 	os.WriteFile(filePath, []byte(content), 0644)
 
 	// Edit with LF-only old_text (as Claude Desktop would send)
-	result, err := engine.EditFile(context.Background(), filePath, "line2\n", "REPLACED\n", true, false)
+	result, err := engine.EditFile(context.Background(), filePath, "line2\n", "REPLACED\n", true, false, false)
 	if err != nil {
 		t.Fatalf("EditFile failed: %v", err)
 	}
@@ -79,7 +79,7 @@ func TestBug23_EditFile_CRLFRiskNotCritical(t *testing.T) {
 	os.WriteFile(filePath, []byte(sb.String()), 0644)
 
 	// Edit one line with LF old_text (no \r)
-	result, err := engine.EditFile(context.Background(), filePath, "TARGET_LINE_TO_REPLACE\n", "REPLACED_SUCCESSFULLY\n", false, false)
+	result, err := engine.EditFile(context.Background(), filePath, "TARGET_LINE_TO_REPLACE\n", "REPLACED_SUCCESSFULLY\n", false, false, false)
 	if err != nil {
 		t.Fatalf("EditFile failed: %v", err)
 	}
@@ -107,7 +107,7 @@ func TestBug23_MultiEdit_CRLFMatchesLF(t *testing.T) {
 		{OldText: "gamma\n", NewText: "GAMMA\n"},
 	}
 
-	result, err := engine.MultiEdit(context.Background(), filePath, edits, true, false)
+	result, err := engine.MultiEdit(context.Background(), filePath, edits, true, false, false)
 	if err != nil {
 		t.Fatalf("MultiEdit failed: %v", err)
 	}
@@ -132,7 +132,7 @@ func TestBug23_PureLF_StillWorks(t *testing.T) {
 	os.WriteFile(filePath, []byte(content), 0644)
 
 	// Edit with LF old_text
-	result, err := engine.EditFile(context.Background(), filePath, "line2\n", "REPLACED\n", false, false)
+	result, err := engine.EditFile(context.Background(), filePath, "line2\n", "REPLACED\n", false, false, false)
 	if err != nil {
 		t.Fatalf("EditFile failed on LF file: %v", err)
 	}

--- a/tests/bug27_multi_edit_atomic_test.go
+++ b/tests/bug27_multi_edit_atomic_test.go
@@ -52,7 +52,7 @@ func main() {
 		},
 	}
 
-	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false)
+	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false, false)
 
 	// Should return an error (atomic rollback)
 	if err == nil {
@@ -122,7 +122,7 @@ func goodbye() {
 		},
 	}
 
-	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false)
+	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false, false)
 	if err != nil {
 		t.Fatalf("Expected success, got error: %v", err)
 	}
@@ -187,7 +187,7 @@ function gestionData() {
 		},
 	}
 
-	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false)
+	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false, false)
 
 	// Should fail atomically
 	if err == nil {

--- a/tests/bug28_html_edit_test.go
+++ b/tests/bug28_html_edit_test.go
@@ -61,7 +61,7 @@ func TestBug28_EditFileWithHTMLContent(t *testing.T) {
 				t.Fatalf("Failed to write test file: %v", err)
 			}
 
-			result, err := engine.EditFile(context.Background(), testFile, tt.oldText, tt.newText, false, false)
+			result, err := engine.EditFile(context.Background(), testFile, tt.oldText, tt.newText, false, false, false)
 			if err != nil {
 				t.Fatalf("EditFile failed with HTML content: %v", err)
 			}
@@ -104,7 +104,7 @@ func TestBug28_ValidateContextNoLongerBlocks(t *testing.T) {
 		t.Fatalf("Failed to write test file: %v", err)
 	}
 
-	result, err := engine.EditFile(context.Background(), testFile, oldText, newText, false, false)
+	result, err := engine.EditFile(context.Background(), testFile, oldText, newText, false, false, false)
 	if err != nil {
 		t.Fatalf("EditFile should succeed via fallback strategies, got error: %v", err)
 	}

--- a/tests/mcp_functions_test.go
+++ b/tests/mcp_functions_test.go
@@ -236,7 +236,7 @@ func WriteFile() {
 		oldText := "return nil"
 		newText := "return content"
 
-		result, err := engine.EditFile(context.Background(), testFile, oldText, newText, true, false)
+		result, err := engine.EditFile(context.Background(), testFile, oldText, newText, true, false, false)
 		if err != nil {
 			t.Fatalf("EditFile should succeed with valid context, got error: %v", err)
 		}
@@ -254,7 +254,7 @@ func WriteFile() {
 		oldText := "this_text_does_not_exist"
 		newText := "something"
 
-		result, err := engine.EditFile(context.Background(), testFile, oldText, newText, false, false)
+		result, err := engine.EditFile(context.Background(), testFile, oldText, newText, false, false, false)
 		if err == nil {
 			t.Error("EditFile should fail with invalid context")
 		}

--- a/tests/undo_step_through_test.go
+++ b/tests/undo_step_through_test.go
@@ -45,7 +45,7 @@ func TestUndoChain_BasicStepThrough(t *testing.T) {
 	}
 
 	// First edit
-	r1, err := engine.EditFile(context.Background(), testFile, "line1", "EDITED1", false, false)
+	r1, err := engine.EditFile(context.Background(), testFile, "line1", "EDITED1", false, false, false)
 	if err != nil {
 		t.Fatalf("First edit failed: %v", err)
 	}
@@ -61,7 +61,7 @@ func TestUndoChain_BasicStepThrough(t *testing.T) {
 	}
 
 	// Second edit
-	r2, err := engine.EditFile(context.Background(), testFile, "line2", "EDITED2", false, false)
+	r2, err := engine.EditFile(context.Background(), testFile, "line2", "EDITED2", false, false, false)
 	if err != nil {
 		t.Fatalf("Second edit failed: %v", err)
 	}
@@ -97,7 +97,7 @@ func TestUndoChain_RestorePreviousInChain(t *testing.T) {
 	}
 
 	// Edit 1: AAA -> AAA1
-	r1, _ := engine.EditFile(context.Background(), testFile, "AAA", "AAA1", false, false)
+	r1, _ := engine.EditFile(context.Background(), testFile, "AAA", "AAA1", false, false, false)
 	b1 := r1.BackupID
 
 	// Verify file now has AAA1
@@ -107,7 +107,7 @@ func TestUndoChain_RestorePreviousInChain(t *testing.T) {
 	}
 
 	// Edit 2: BBB -> BBB2
-	r2, _ := engine.EditFile(context.Background(), testFile, "BBB", "BBB2", false, false)
+	r2, _ := engine.EditFile(context.Background(), testFile, "BBB", "BBB2", false, false, false)
 	b2 := r2.BackupID
 
 	// Verify file now has BBB2
@@ -170,7 +170,7 @@ func TestUndoChain_ClearOnEnd(t *testing.T) {
 	}
 
 	// One edit
-	r1, _ := engine.EditFile(context.Background(), testFile, "ORIGINAL", "MODIFIED", false, false)
+	r1, _ := engine.EditFile(context.Background(), testFile, "ORIGINAL", "MODIFIED", false, false, false)
 	b1 := r1.BackupID
 
 	// Verify chain points to b1
@@ -236,7 +236,7 @@ func TestUndoChain_MultiEditChain(t *testing.T) {
 		{OldText: "line1", NewText: "M1A"},
 		{OldText: "line2", NewText: "M1B"},
 	}
-	r1, err := engine.MultiEdit(context.Background(), testFile, edits1, false, false)
+	r1, err := engine.MultiEdit(context.Background(), testFile, edits1, false, false, false)
 	if err != nil {
 		t.Fatalf("First MultiEdit failed: %v", err)
 	}
@@ -247,7 +247,7 @@ func TestUndoChain_MultiEditChain(t *testing.T) {
 		{OldText: "line3", NewText: "M2A"},
 		{OldText: "line4", NewText: "M2B"},
 	}
-	r2, err := engine.MultiEdit(context.Background(), testFile, edits2, false, false)
+	r2, err := engine.MultiEdit(context.Background(), testFile, edits2, false, false, false)
 	if err != nil {
 		t.Fatalf("Second MultiEdit failed: %v", err)
 	}
@@ -273,7 +273,7 @@ func TestVerifyIntegrity_HighRisk(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result, err := engine.EditFile(context.Background(), testFile, strings.Repeat("B", 300), strings.Repeat("D", 300), false, false)
+	result, err := engine.EditFile(context.Background(), testFile, strings.Repeat("B", 300), strings.Repeat("D", 300), false, false, false)
 	if err != nil {
 		t.Fatalf("HIGH risk edit failed: %v", err)
 	}
@@ -309,7 +309,7 @@ func TestVerifyIntegrity_CriticalRisk(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result, err := engine.EditFile(context.Background(), testFile, content, "NEW_CONTENT_COMPLETELY_DIFFERENT", false, false)
+	result, err := engine.EditFile(context.Background(), testFile, content, "NEW_CONTENT_COMPLETELY_DIFFERENT", false, false, false)
 	if err != nil {
 		t.Fatalf("CRITICAL risk edit failed: %v", err)
 	}
@@ -338,7 +338,7 @@ func TestVerifyIntegrity_LowRiskNoVerify(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result, err := engine.EditFile(context.Background(), testFile, "TARGET", "CHANGED", false, false)
+	result, err := engine.EditFile(context.Background(), testFile, "TARGET", "CHANGED", false, false, false)
 	if err != nil {
 		t.Fatalf("LOW risk edit failed: %v", err)
 	}
@@ -362,7 +362,7 @@ func TestVerifyIntegrity_ResultFields(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result, _ := engine.EditFile(context.Background(), testFile, strings.Repeat("B", 300), strings.Repeat("D", 300), false, false)
+	result, _ := engine.EditFile(context.Background(), testFile, strings.Repeat("B", 300), strings.Repeat("D", 300), false, false, false)
 	inv := result.Integrity
 
 	if inv == nil {

--- a/tools_batch.go
+++ b/tools_batch.go
@@ -29,6 +29,7 @@ func registerBatchTools(reg *toolRegistry) {
 		mcp.WithString("path", mcp.Required(), mcp.Description("Path to the file to edit")),
 		mcp.WithString("edits_json", mcp.Required(), mcp.Description("JSON array of edits: [{\"old_text\": \"...\", \"new_text\": \"...\"}, ...]. Also accepts old_str/new_str as aliases.")),
 		mcp.WithBoolean("force", mcp.Description("Force operation even if CRITICAL risk (default: false)")),
+		mcp.WithBoolean("tolerant_whitespace", mcp.Description("Apply tolerant_whitespace semantics to all edits in the batch (1 tab = 4 spaces, CRLF = LF). Default: false.")),
 	)
 	reg.addTool(multiEditTool, auditWrap(engine, "multi_edit", func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		path, err := request.RequireString("path")
@@ -118,7 +119,7 @@ func registerBatchTools(reg *toolRegistry) {
 		}
 
 		// Execute multi-edit
-		result, err := engine.MultiEdit(ctx, path, edits, force, dryRun)
+		result, err := engine.MultiEdit(ctx, path, edits, force, dryRun, false)
 		if err != nil {
 			// Bug #27: If result is non-nil, this is an atomic rollback — include backup_id and details
 			if result != nil && result.BackupID != "" {

--- a/tools_core.go
+++ b/tools_core.go
@@ -97,13 +97,14 @@ func registerTools(s *server.MCPServer, engine *core.UltraFastEngine) error {
 	registerBatchTools(reg)
 	registerPlatformTools(reg)
 	registerGitTools(reg)
+	registerMinifyTools(reg)
 	// Aliases disabled: duplicates add noise to discovery, hurt token budget.
 	// registerAliases(reg)
 	// registerClaudeCodeAliases(reg)
 	// registerSuperTool(reg)
 	registerHelpTool(reg)
 
-	log.Printf("Registered 19 tools (17 core + git + help) for v4.5.2 — aliases disabled")
+	log.Printf("Registered 20 tools (18 core + git + help + minify_js) for v4.5.3 — aliases disabled")
 	return nil
 }
 
@@ -467,6 +468,7 @@ func registerCoreTools(reg *toolRegistry) {
 		// file's actual hash doesn't match, the edit is rejected with a clear error.
 		// Improvement B3 (see log analysis: 6 stale-edit cycles in 12 days).
 		mcp.WithString("expected_hash", mcp.Description("Optional. The content_hash from the last read_file. If the file's current hash doesn't match, the edit is rejected so the model can re-read first.")),
+		mcp.WithBoolean("tolerant_whitespace", mcp.Description("Treat tabs and 4-space runs as equivalent (1 tab = 4 spaces) and CRLF/LF as equivalent when matching old_text. Use when the file has mixed indentation (e.g., tabs in some lines, spaces in others). Original file bytes are preserved — only the matching is tolerant. Default: false.")),
 	)
 	regexTransform := reg.regexTransform
 	reg.editFileHandler = auditWrap(engine, "edit_file", func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -483,6 +485,7 @@ func registerCoreTools(reg *toolRegistry) {
 		force := false
 		dryRun := false
 		occurrence := 0
+		tolerantWhitespace := false
 
 		if args != nil {
 			if m, ok := args["mode"].(string); ok {
@@ -490,6 +493,9 @@ func registerCoreTools(reg *toolRegistry) {
 			}
 			if f, ok := args["force"].(bool); ok {
 				force = f
+			}
+			if tw, ok := args["tolerant_whitespace"].(bool); ok {
+				tolerantWhitespace = tw
 			}
 			if dr, ok := args["dry_run"].(bool); ok {
 				dryRun = dr
@@ -747,7 +753,7 @@ func registerCoreTools(reg *toolRegistry) {
 			}
 		}
 
-		result, err := engine.EditFile(ctx, path, oldText, newText, force, dryRun)
+		result, err := engine.EditFile(ctx, path, oldText, newText, force, dryRun, tolerantWhitespace)
 		if err != nil {
 			// Record failed old_text for reinforcement detection
 			core.RecordFailedOldText(path, oldText)

--- a/tools_core.go
+++ b/tools_core.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"hash/fnv"
 	"log"
 	"os"
 	"path/filepath"
@@ -255,6 +256,17 @@ func registerCoreTools(reg *toolRegistry) {
 		// Record read for stale-read detection in feedback system
 		core.RecordRead(core.NormalizePath(path))
 
+		// Compute FNV-1a content hash (8 hex chars) and append as a comment
+		// footer. The model can echo it back via edit_file(expected_hash:"...")
+		// to detect stale reads (improvement B3: prevents 6 stale-edit cycles
+		// observed in 12 days of log analysis).
+		// The `#` makes it look like a comment in many file formats so it
+		// doesn't pollute the user's view of the actual content.
+		h := fnv.New32a()
+		h.Write([]byte(content))
+		contentHash := fmt.Sprintf("%08x", h.Sum32())
+		content = content + "\n# content_hash: " + contentHash
+
 		// Apply truncation if explicitly requested
 		if maxLines > 0 || mode != "all" {
 			content = truncateContent(content, maxLines, mode)
@@ -451,6 +463,10 @@ func registerCoreTools(reg *toolRegistry) {
 		mcp.WithBoolean("create_backup", mcp.Description("Create backup before transformation (default: true, for regex mode)")),
 		mcp.WithBoolean("dry_run", mcp.Description("Preview changes without writing to disk. Supported in modes: replace (default), search_replace, regex. Default: false.")),
 		mcp.WithBoolean("whole_word", mcp.Description("Match whole words only (default: false, for occurrence mode)")),
+		// Stale-edit protection: hash returned by the prior read_file call. If the
+		// file's actual hash doesn't match, the edit is rejected with a clear error.
+		// Improvement B3 (see log analysis: 6 stale-edit cycles in 12 days).
+		mcp.WithString("expected_hash", mcp.Description("Optional. The content_hash from the last read_file. If the file's current hash doesn't match, the edit is rejected so the model can re-read first.")),
 	)
 	regexTransform := reg.regexTransform
 	reg.editFileHandler = auditWrap(engine, "edit_file", func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -710,6 +726,26 @@ func registerCoreTools(reg *toolRegistry) {
 		// Read old content before edit to compute diff
 		oldContentRaw, _ := os.ReadFile(normPath)
 		oldContentStr := string(oldContentRaw)
+
+		// Improvement B3: stale-edit protection. If the caller passed
+		// expected_hash (the hash returned by the prior read_file), verify
+		// the file hasn't changed. Mismatch → return clear error so the
+		// model can re-read instead of silently overwriting.
+		if args != nil {
+			if expectedHash, ok := args["expected_hash"].(string); ok && expectedHash != "" {
+				h := fnv.New32a()
+				h.Write(oldContentRaw)
+				actualHash := fmt.Sprintf("%08x", h.Sum32())
+				if actualHash != expectedHash {
+					core.SetError(ctx, fmt.Sprintf(
+						"stale edit: file content changed since read (expected hash: %s, actual: %s). Re-read the file before editing.",
+						expectedHash, actualHash))
+					return mcp.NewToolResultError(fmt.Sprintf(
+						"stale edit: file content changed since read (expected hash: %s, actual: %s). Re-read the file with read_file to get the current content_hash, then retry.",
+						expectedHash, actualHash)), nil
+				}
+			}
+		}
 
 		result, err := engine.EditFile(ctx, path, oldText, newText, force, dryRun)
 		if err != nil {

--- a/tools_core.go
+++ b/tools_core.go
@@ -359,22 +359,53 @@ func registerCoreTools(reg *toolRegistry) {
 			content = c
 		}
 
-		// Feedback: check for truncation/inflation/full-rewrite patterns
+		// Feedback: check for truncation/inflation/full-rewrite patterns.
+		// Normalize path once so os.Stat, CreateBackup, and WriteFileContent
+		// all see the same target (consistent on Windows/WSL).
+		normPath := core.NormalizePath(path)
 		var existingSize int64
-		if info, statErr := os.Stat(core.NormalizePath(path)); statErr == nil {
+		if info, statErr := os.Stat(normPath); statErr == nil {
 			existingSize = info.Size()
 		}
-		if signal := core.CheckWriteOp(path, content, existingSize); signal.BlockOp {
+		signal := core.CheckWriteOp(path, content, existingSize)
+
+		// Adaptive downgrade: if CheckWriteOp wants to block AND a backup
+		// manager is configured, create a safety backup and proceed with
+		// warn instead. If no backup manager or backup creation fails, keep
+		// the original block as a safety net. See core/feedback_adaptive.go.
+		var newBackupID string
+		if signal.BlockOp && engine.GetBackupManager() != nil {
+			prevBackupID := engine.GetCurrentBackupID(normPath)
+			createBackup := func(p, op, userCtx string) (string, error) {
+				return engine.GetBackupManager().CreateBackupWithContextAndParent(
+					p, op, userCtx, prevBackupID,
+				)
+			}
+			signal, newBackupID = core.ApplyAdaptiveWriteBlock(
+				signal, true, normPath,
+				int64(len(content)), existingSize, createBackup,
+			)
+			// On successful downgrade, link the new backup into the undo chain
+			// so backup(action:"undo_last", file_path:"...") can step back.
+			if newBackupID != "" {
+				engine.SetCurrentBackupID(normPath, newBackupID)
+			}
+		}
+
+		if signal.BlockOp {
 			core.SetFeedback(ctx, signal)
 			return mcp.NewToolResultError(signal.Message + "\n→ " + signal.Suggestion), nil
 		} else if signal.Status != core.FeedbackOK {
-			// Non-blocking warn — proceed but append feedback to response
+			// Non-blocking warn — proceed but append feedback to response.
+			// Always use verbose format (FormatFeedback, not FormatFeedbackCompact)
+			// when the warn came from an adaptive downgrade so the backup ID
+			// and restore command remain literal and visible to the AI/operator.
 			err = engine.WriteFileContent(ctx, path, content)
 			if err != nil {
 				return mcp.NewToolResultError(fmt.Sprintf("Error: %v", err)), nil
 			}
 			core.SetFeedback(ctx, signal)
-			if engine.IsCompactMode() {
+			if engine.IsCompactMode() && !signal.Downgraded {
 				return mcp.NewToolResultText(fmt.Sprintf("WRITTEN %s %s | %dB | %s", diskPrefix(absPath), absPath, len(content), core.FormatFeedbackCompact(signal))), nil
 			}
 			return mcp.NewToolResultText(core.FormatFeedback(signal, fmt.Sprintf("WRITTEN %s %s | %dB", diskPrefix(absPath), absPath, len(content)))), nil

--- a/tools_minify.go
+++ b/tools_minify.go
@@ -1,0 +1,239 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mcp/filesystem-ultra/core"
+)
+
+// registerMinifyTools registers the JS minification tool.
+//
+// The minifier is a pure-stdlib best-effort JS minifier (see
+// core.MinifyJS). It strips comments, collapses whitespace, and (by
+// default) emits single-line output. The original file is overwritten
+// in place — a backup is auto-created before the write so the change
+// is always recoverable via backup(action:"undo_last").
+func registerMinifyTools(reg *toolRegistry) {
+	engine := reg.engine
+
+	minifyTool := mcp.NewTool("minify_js",
+		mcp.WithTitleAnnotation("Minify JavaScript"),
+		mcp.WithReadOnlyHintAnnotation(false),
+		mcp.WithDestructiveHintAnnotation(true),
+		mcp.WithIdempotentHintAnnotation(true),
+		mcp.WithDescription("minify_js — Minify a JavaScript file in place using a pure-stdlib state-machine "+
+			"minifier (no external deps, no Node.js needed). Auto-backup before write — undo with "+
+			"backup(action:\"undo_last\"). Use when working with JS that needs to be smaller for "+
+			"distribution (e.g. pre-deploy, browser-loaded scripts) but the user does NOT want to "+
+			"rebuild via their toolchain. The minifier never modifies string/regex/template contents "+
+			"— only comments and whitespace. Best-effort: edge cases (regexes with `/` in char classes, "+
+			"tagged templates) are handled with conservative heuristics."),
+		mcp.WithString("path", mcp.Required(), mcp.Description("Path to the .js file to minify (overwritten in place)")),
+		mcp.WithString("output_path", mcp.Description("Optional: write minified output to this path instead of overwriting path")),
+		mcp.WithBoolean("remove_comments", mcp.Description("Strip // and /* */ comments (default: true)")),
+		mcp.WithBoolean("collapse_whitespace", mcp.Description("Collapse runs of spaces/tabs to single space where needed (default: true)")),
+		mcp.WithBoolean("single_line", mcp.Description("Emit all output on a single line (default: true)")),
+		mcp.WithBoolean("dry_run", mcp.Description("Preview the minified output without writing (default: false)")),
+		mcp.WithBoolean("create_backup", mcp.Description("Create a backup before overwriting (default: true)")),
+	)
+	reg.addTool(minifyTool, auditWrap(engine, "minify_js", func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		path, err := request.RequireString("path")
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("Invalid path: %v", err)), nil
+		}
+
+		normPath := core.NormalizePath(path)
+
+		// Access control
+		if !engine.IsPathAllowed(normPath) {
+			return mcp.NewToolResultError(fmt.Sprintf("Error: access denied: %s", normPath)), nil
+		}
+
+		// Validate file exists and is a file
+		info, err := os.Stat(normPath)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("Error: cannot stat %s: %v", normPath, err)), nil
+		}
+		if info.IsDir() {
+			return mcp.NewToolResultError(fmt.Sprintf("Error: %s is a directory, not a file", normPath)), nil
+		}
+
+		// Parse options with defaults applied
+		opts := core.MinifyOptions{
+			RemoveComments:     true,
+			CollapseWhitespace: true,
+			SingleLine:         true,
+		}
+		outputPath := ""
+		dryRun := false
+		createBackup := true
+		if args, ok := request.Params.Arguments.(map[string]interface{}); ok {
+			if op, ok := args["output_path"].(string); ok && op != "" {
+				outputPath = core.NormalizePath(op)
+			}
+			if dr, ok := args["dry_run"].(bool); ok {
+				dryRun = dr
+			}
+			if cb, ok := args["create_backup"].(bool); ok {
+				createBackup = cb
+			}
+			if rc, ok := args["remove_comments"].(bool); ok {
+				opts.RemoveComments = rc
+			}
+			if cw, ok := args["collapse_whitespace"].(bool); ok {
+				opts.CollapseWhitespace = cw
+			}
+			if sl, ok := args["single_line"].(bool); ok {
+				opts.SingleLine = sl
+			}
+		}
+
+		// If the user explicitly set ALL three to false, that means
+		// "do nothing useful" — warn instead of returning identical output.
+		if !opts.RemoveComments && !opts.CollapseWhitespace && !opts.SingleLine {
+			return mcp.NewToolResultError("Error: all of remove_comments, collapse_whitespace, and single_line are false — nothing to do. Set at least one to true."), nil
+		}
+
+		// Read original
+		originalBytes, err := os.ReadFile(normPath)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("Error reading %s: %v", normPath, err)), nil
+		}
+		original := string(originalBytes)
+
+		// Minify
+		minified, stats := core.MinifyJS(original, opts)
+
+		// Determine write target
+		target := normPath
+		if outputPath != "" {
+			target = outputPath
+			// Validate the output path is also allowed
+			if !engine.IsPathAllowed(target) {
+				return mcp.NewToolResultError(fmt.Sprintf("Error: output_path %s is not in allowed paths", target)), nil
+			}
+		}
+
+		// Dry-run: return the preview without writing
+		if dryRun {
+			return formatMinifyResult(normPath, target, stats, minified, /*wroteFile=*/ false, /*backupID=*/ "", engine.IsCompactMode()), nil
+		}
+
+		// Create backup (unless explicitly disabled) — only when overwriting
+		// the original. Output to a different path doesn't need a backup of
+		// the source because the source is untouched.
+		var backupID string
+		if createBackup && target == normPath && engine.GetBackupManager() != nil {
+			prevBackupID := engine.GetCurrentBackupID(normPath)
+			backupID, err = engine.GetBackupManager().CreateBackupWithContextAndParent(
+				normPath, "minify_js",
+				fmt.Sprintf("Minify JS: %d → %d bytes (%.1f%% reduction)",
+					stats.InputBytes, stats.OutputBytes, stats.ReductionPercent),
+				prevBackupID,
+			)
+			if err != nil {
+				return mcp.NewToolResultError(fmt.Sprintf("Error creating backup: %v", err)), nil
+			}
+		}
+
+		// Ensure target directory exists (for output_path case)
+		if dir := filepath.Dir(target); dir != "" {
+			if mkdirErr := os.MkdirAll(dir, 0755); mkdirErr != nil {
+				return mcp.NewToolResultError(fmt.Sprintf("Error creating directory for %s: %v", target, mkdirErr)), nil
+			}
+		}
+
+		// Atomic write
+		tmpPath := target + ".tmp." + core.SecureRandomSuffix()
+		// Preserve original file mode if overwriting, else use 0644
+		fileMode := os.FileMode(0644)
+		if target == normPath {
+			fileMode = info.Mode()
+		}
+		if err := os.WriteFile(tmpPath, []byte(minified), fileMode); err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("Error writing temp file: %v", err)), nil
+		}
+		if err := os.Rename(tmpPath, target); err != nil {
+			os.Remove(tmpPath)
+			return mcp.NewToolResultError(fmt.Sprintf("Error finalizing write: %v", err)), nil
+		}
+
+		// Invalidate cache if the engine has one
+		engine.InvalidateCache(normPath)
+		if target != normPath {
+			engine.InvalidateCache(target)
+		}
+
+		// Update backup chain if we wrote in place
+		if target == normPath && backupID != "" {
+			engine.SetCurrentBackupID(normPath, backupID)
+		}
+
+		return formatMinifyResult(normPath, target, stats, minified, /*wroteFile=*/ true, backupID, engine.IsCompactMode()), nil
+	}))
+}
+
+// formatMinifyResult renders the minify tool response in compact or
+// verbose form. Centralized so the dry-run and live paths share the
+// same output format.
+func formatMinifyResult(sourcePath, target string, stats core.MinifyStats, minified string, wroteFile bool, backupID string, compact bool) *mcp.CallToolResult {
+	if compact {
+		verb := "MINIFIED"
+		if !wroteFile {
+			verb = "MINIFY (dry-run)"
+		}
+		msg := fmt.Sprintf("%s %s | %d→%dB (-%d, %.1f%%) | comments:%d",
+			verb, target, stats.InputBytes, stats.OutputBytes, stats.BytesSaved, stats.ReductionPercent, stats.CommentsStripped)
+		if target != sourcePath {
+			msg += fmt.Sprintf(" | from:%s", sourcePath)
+		}
+		if backupID != "" {
+			shortID := backupID
+			if len(shortID) > 12 {
+				shortID = shortID[:12]
+			}
+			msg += fmt.Sprintf(" | UNDO:%s", shortID)
+		}
+		if stats.Truncated {
+			msg += " | truncated:input-malformed"
+		}
+		return mcp.NewToolResultText(msg)
+	}
+
+	var sb strings.Builder
+	if wroteFile {
+		sb.WriteString("Minify complete\n")
+	} else {
+		sb.WriteString("Minify DRY RUN — no changes written\n")
+	}
+	sb.WriteString("---\n")
+	sb.WriteString(fmt.Sprintf("Source:      %s\n", sourcePath))
+	if target != sourcePath {
+		sb.WriteString(fmt.Sprintf("Output:      %s\n", target))
+	}
+	sb.WriteString(fmt.Sprintf("Input bytes: %d\n", stats.InputBytes))
+	sb.WriteString(fmt.Sprintf("Output bytes: %d\n", stats.OutputBytes))
+	sb.WriteString(fmt.Sprintf("Saved:       %d bytes (%.1f%%)\n", stats.BytesSaved, stats.ReductionPercent))
+	sb.WriteString(fmt.Sprintf("Comments stripped: %d\n", stats.CommentsStripped))
+	if stats.Truncated {
+		sb.WriteString("⚠️ Input was malformed (unterminated string/comment). Output is truncated.\n")
+	}
+	if backupID != "" {
+		sb.WriteString(fmt.Sprintf("\n✓ UNDO:%s\n", backupID))
+	}
+	if !wroteFile {
+		sb.WriteString("\n--- Preview (first 500 chars) ---\n")
+		preview := minified
+		if len(preview) > 500 {
+			preview = preview[:500] + "..."
+		}
+		sb.WriteString(preview)
+		sb.WriteString("\n")
+	}
+	return mcp.NewToolResultText(sb.String())
+}

--- a/tools_search.go
+++ b/tools_search.go
@@ -155,7 +155,7 @@ func registerSearchTools(reg *toolRegistry) {
 				return mcp.NewToolResultError(err.Error()), nil
 			}
 			if len(resp.Content) > 0 {
-				return mcp.NewToolResultText(resp.Content[0].Text), nil
+				return mcp.NewToolResultText(capSearchOutput(resp.Content[0].Text, engine)), nil
 			}
 			return mcp.NewToolResultText("No matches"), nil
 		}
@@ -170,7 +170,7 @@ func registerSearchTools(reg *toolRegistry) {
 			return mcp.NewToolResultError(err.Error()), nil
 		}
 		if len(resp.Content) > 0 {
-			return mcp.NewToolResultText(resp.Content[0].Text), nil
+			return mcp.NewToolResultText(capSearchOutput(resp.Content[0].Text, engine)), nil
 		}
 		return mcp.NewToolResultText("No matches"), nil
 	})
@@ -264,4 +264,24 @@ func registerSearchTools(reg *toolRegistry) {
 			return mcp.NewToolResultError(fmt.Sprintf("Unknown operation: %s. Valid: file, optimize, write, edit, delete", operation)), nil
 		}
 	}))
+}
+
+// capSearchOutput truncates a search_files response if it exceeds the configured
+// output cap. Appends a marker so the model knows the response was truncated
+// and how to recover (count_only:true or a narrower path).
+//
+// Improvement M1+M2: prevents accidental multi-MB responses that waste tokens
+// (a single 2.28MB search response was observed in the proxy log, costing
+// ~570K output tokens).
+func capSearchOutput(text string, engine *core.UltraFastEngine) string {
+	maxBytes := core.DefaultMaxSearchOutputBytes
+	if cfg := engine.GetConfig(); cfg != nil && cfg.MaxSearchOutputBytes > 0 {
+		maxBytes = cfg.MaxSearchOutputBytes
+	}
+	if len(text) <= maxBytes {
+		return text
+	}
+	truncated := text[:maxBytes]
+	marker := fmt.Sprintf("\n\n⚠️ truncated: response exceeded %d KB. Use count_only:true or narrow the path/pattern.\n", maxBytes/1024)
+	return truncated + marker
 }


### PR DESCRIPTION
…ailable

write_file previously hard-blocked when new content was < 50% of the existing file (truncation) or > 3x (inflation_loop), forcing a delete_file + write_file cycle that wasted tokens on long sessions where the model intentionally rewrites files (e.g. refactors).

Now, when the engine has a BackupManager configured (the default), these patterns instead:
  1. Create a safety backup via CreateBackupWithContextAndParent, linked to the existing undo chain
  2. Proceed with the write
  3. Return a non-blocking WARN with the backup ID and the literal restore command (backup(action:"restore", backup_id:"...")) forced to verbose format so the AI sees the undo path

When the backup manager is unavailable (NewBackupManager failed at startup), the original hard-block is preserved as a safety net.

New files:
  - core/feedback_adaptive.go      — pure ApplyAdaptiveWriteBlock helper
  - core/feedback_adaptive_test.go — 9 table-driven cases + format pin

Modified:
  - core/feedback.go    — added Downgraded bool field (omitempty JSON)
  - tools_core.go       — write_file handler uses the helper, normalizes
                          path once, forces verbose on downgraded warns
  - core/claude_optimizer.go — NOTE comment documenting the intentional
                                divergence with the legacy IntelliGentWrite
                                guard (still hard-blocks; unification
                                planned for 4.5.6+)
  - CHANGELOG.md        — entry under [Unreleased / 4.5.5] - 2026-06-04

Tests: go test ./core/ ./tests/ ./tests/security/ — all pass.