### PR TITLE
Security hardening: TOCTOU defense, input validation, and path traversal fixes

### DIFF
--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -26,6 +26,10 @@ import (
 //go:embed static/*
 var staticFiles embed.FS
 
+// maxSearchQueryLen caps the length of the user-supplied "q" search parameter
+// to bound per-request CPU/allocation work (defense against trivial DoS).
+const maxSearchQueryLen = 256
+
 // BackupInfo mirrors core.BackupInfo for reading metadata files
 type BackupInfo struct {
 	BackupID    string           `json:"backup_id"`
@@ -390,6 +394,10 @@ func backupSearchHandler(backupDir string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 
+		if len(r.URL.Query().Get("q")) > maxSearchQueryLen {
+			http.Error(w, "q parameter too long", http.StatusBadRequest)
+			return
+		}
 		q := strings.ToLower(r.URL.Query().Get("q"))
 		operation := r.URL.Query().Get("operation")
 		preset := r.URL.Query().Get("preset")
@@ -523,6 +531,10 @@ func backupContentSearchHandler(backupDir string) http.HandlerFunc {
 		q := r.URL.Query().Get("q")
 		if q == "" {
 			json.NewEncoder(w).Encode(map[string]interface{}{"error": "q parameter required", "matches": []interface{}{}})
+			return
+		}
+		if len(q) > maxSearchQueryLen {
+			http.Error(w, "q parameter too long", http.StatusBadRequest)
 			return
 		}
 

--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -189,6 +189,7 @@ func main() {
 	proxyLogDir := flag.String("proxy-log-dir", "", "Directory containing proxy logs (proxy.jsonl)")
 	backupDir := flag.String("backup-dir", "", "Directory containing MCP server backups")
 	port := flag.Int("port", 9100, "HTTP port to listen on")
+	host := flag.String("host", "127.0.0.1", "Host/interface to bind to (default: localhost only). Use 0.0.0.0 to expose on the network — NOT recommended: the dashboard has no authentication and serves audit logs and backup file contents.")
 	flag.Parse()
 
 	if *logDir == "" {
@@ -219,8 +220,13 @@ func main() {
 	staticFS, _ := fs.Sub(staticFiles, "static")
 	mux.Handle("/", http.FileServer(http.FS(staticFS)))
 
-	addr := fmt.Sprintf(":%d", *port)
-	log.Printf("Dashboard starting on http://localhost%s", addr)
+	addr := fmt.Sprintf("%s:%d", *host, *port)
+	displayHost := *host
+	if displayHost == "0.0.0.0" || displayHost == "" {
+		displayHost = "localhost"
+		log.Printf("WARNING: binding to 0.0.0.0 exposes the dashboard (audit logs + backup contents) on the network with NO authentication.")
+	}
+	log.Printf("Dashboard starting on http://%s:%d", displayHost, *port)
 	log.Printf("  Log dir:    %s", *logDir)
 	if *backupDir != "" {
 		log.Printf("  Backup dir: %s", *backupDir)
@@ -310,7 +316,9 @@ func operationsSSEHandler(logDir string) http.HandlerFunc {
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.Header().Set("Cache-Control", "no-cache")
 		w.Header().Set("Connection", "keep-alive")
-		w.Header().Set("Access-Control-Allow-Origin", "*")
+		// No CORS header: the web UI is served same-origin from this server.
+		// A wildcard Access-Control-Allow-Origin would let any website the user
+		// visits read this live operations stream cross-origin.
 
 		logPath := filepath.Join(logDir, "operations.jsonl")
 
@@ -549,12 +557,14 @@ func backupContentSearchHandler(backupDir string) http.HandlerFunc {
 				default:
 				}
 
-				// Determine file path on disk
-				var filePath string
-				if b.Operation == "batch" {
-					filePath = filepath.Join(backupDir, b.BackupID, f.BackupPath)
-				} else {
-					filePath = filepath.Join(backupDir, b.BackupID, f.BackupPath)
+				// Determine file path on disk. f.BackupPath comes from backup
+				// metadata; guard against it escaping the backup directory
+				// (e.g. "../../etc/passwd" or an absolute path) before reading.
+				base := filepath.Join(backupDir, b.BackupID)
+				filePath := filepath.Join(base, f.BackupPath)
+				if rel, relErr := filepath.Rel(base, filePath); relErr != nil ||
+					rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+					continue
 				}
 
 				info, err := os.Stat(filePath)

--- a/core/engine.go
+++ b/core/engine.go
@@ -591,6 +591,16 @@ func (e *UltraFastEngine) ReadFileContent(ctx context.Context, path string) (str
 		return "", &PathError{Op: "read", Path: path, Err: fmt.Errorf("access denied")}
 	}
 
+	// TOCTOU defense: re-resolve symlinks and re-authorize the canonical target
+	// immediately before any disk I/O. Operate on the resolved path so the read
+	// cannot be redirected outside the sandbox by a symlink swapped in after the
+	// IsPathAllowed check above.
+	if resolved, err := e.ResolveAndAuthorize("read", path); err != nil {
+		return "", err
+	} else {
+		path = resolved
+	}
+
 	// Execute pre-read hook
 	workingDir, _ := os.Getwd()
 	hookCtx := &HookContext{
@@ -679,6 +689,17 @@ func (e *UltraFastEngine) WriteFileContent(ctx context.Context, path, content st
 	// Check if path is allowed (security + access control)
 	if !e.IsPathAllowed(path) {
 		return &PathError{Op: "write", Path: path, Err: fmt.Errorf("access denied")}
+	}
+
+	// TOCTOU defense: re-resolve symlinks and re-authorize the canonical target
+	// immediately before the write. Operate on the resolved path so the atomic
+	// write/rename cannot be redirected outside the sandbox by a symlink swapped
+	// in after the IsPathAllowed check above. For new files this resolves the
+	// (existing) parent directory and re-validates it.
+	if resolved, err := e.ResolveAndAuthorize("write", path); err != nil {
+		return err
+	} else {
+		path = resolved
 	}
 
 	// Check context before proceeding with write
@@ -1182,6 +1203,29 @@ func (e *UltraFastEngine) IsAllowedPathRoot(path string) bool {
 		}
 	}
 	return false
+}
+
+// ResolveAndAuthorize re-resolves symlinks immediately before a file I/O
+// syscall and re-validates the canonical target against the access-control
+// policy. It closes the TOCTOU (time-of-check-time-of-use) window between the
+// initial IsPathAllowed() check and the actual syscall: an attacker who swaps
+// the path for a symlink pointing outside the sandbox after the first check is
+// caught here, because the *resolved* target is re-authorized.
+//
+// Unlike ResolveSymlinks (used by rename/copy, which reject any symlink),
+// this permits legitimate symlinks that resolve to a location still inside the
+// allowed paths — common in real projects (e.g. node_modules, vendored deps).
+// Callers should operate on the returned canonical path so the syscall acts on
+// the verified target rather than re-traversing the (swappable) symlink name.
+func (e *UltraFastEngine) ResolveAndAuthorize(op, path string) (string, error) {
+	resolved, _, err := ResolveSymlinks(path)
+	if err != nil {
+		return "", &PathError{Op: op, Path: path, Err: fmt.Errorf("failed to resolve path: %w", err)}
+	}
+	if !e.IsPathAllowed(resolved) {
+		return "", &PathError{Op: op, Path: path, Err: fmt.Errorf("access denied")}
+	}
+	return resolved, nil
 }
 
 // NormalizePath converts between WSL and Windows paths automatically

--- a/core/path_security.go
+++ b/core/path_security.go
@@ -248,6 +248,9 @@ func ResolveSymlinks(path string) (string, bool, error) {
 		var suffix []string
 		for {
 			parent := filepath.Dir(current)
+			// Record the current component BEFORE testing its parent, so the
+			// deepest (non-existent) component is not dropped from the result.
+			suffix = append([]string{filepath.Base(current)}, suffix...)
 			if parent == current {
 				break
 			}
@@ -258,7 +261,6 @@ func ResolveSymlinks(path string) (string, bool, error) {
 				}
 				break
 			}
-			suffix = append([]string{filepath.Base(current)}, suffix...)
 			current = parent
 		}
 		if resolved == "" {

--- a/tools_git.go
+++ b/tools_git.go
@@ -207,6 +207,11 @@ func gitStatusCompact(repoRoot, output string) (*mcp.CallToolResult, error) {
 func gitDiff(ctx context.Context, engine *core.UltraFastEngine, repoRoot string, args map[string]interface{}) (*mcp.CallToolResult, error) {
 	staged, _ := args["staged"].(bool)
 	commitRange, _ := args["commit_range"].(string)
+	if commitRange != "" {
+		if errRes := rejectOptionLike("commit_range", commitRange); errRes != nil {
+			return errRes, nil
+		}
+	}
 
 	var cmdArgs []string
 	if commitRange != "" {
@@ -558,6 +563,12 @@ func gitRestore(ctx context.Context, engine *core.UltraFastEngine, repoRoot stri
 	source, _ := args["source"].(string)
 	dryRun, _ := args["dry_run"].(bool)
 
+	if source != "" {
+		if errRes := rejectOptionLike("source", source); errRes != nil {
+			return errRes, nil
+		}
+	}
+
 	// Pre-delete hook for restore (it's destructive to working tree)
 	hookCtx := &core.HookContext{
 		Event:     core.HookPreDelete,
@@ -649,6 +660,12 @@ func extractCommitHash(output string) string {
 func gitBranch(ctx context.Context, engine *core.UltraFastEngine, repoRoot string, args map[string]interface{}) (*mcp.CallToolResult, error) {
 	branchAction, _ := args["branch_action"].(string)
 	branchName, _ := args["branch_name"].(string)
+
+	if branchName != "" {
+		if errRes := rejectOptionLike("branch_name", branchName); errRes != nil {
+			return errRes, nil
+		}
+	}
 
 	// List branches
 	if branchAction == "" || branchAction == "list" {
@@ -796,6 +813,19 @@ func isDestructiveGitAction(action string, args map[string]any) bool {
 		return false
 	}
 	return false
+}
+
+// rejectOptionLike guards against git argument injection. User-supplied
+// revisions, ranges and branch names are passed to git as positional
+// arguments; a value beginning with "-" could be reinterpreted by git as an
+// option (e.g. --output=<file>) instead of data. git itself forbids branch
+// names and refs starting with "-", so rejecting them costs no legitimate use.
+// Returns a non-nil error result if the value is option-like.
+func rejectOptionLike(field, value string) *mcp.CallToolResult {
+	if strings.HasPrefix(value, "-") {
+		return mcp.NewToolResultError(fmt.Sprintf("invalid %s %q: value must not start with '-'", field, value))
+	}
+	return nil
 }
 
 // getBoolArg safely extracts a boolean argument

--- a/tools_minify.go
+++ b/tools_minify.go
@@ -54,6 +54,15 @@ func registerMinifyTools(reg *toolRegistry) {
 			return mcp.NewToolResultError(fmt.Sprintf("Error: access denied: %s", normPath)), nil
 		}
 
+		// TOCTOU defense: re-resolve symlinks and re-authorize the canonical
+		// target before reading/writing, so the operation can't be redirected
+		// outside the sandbox by a symlink swapped in after the check above.
+		if resolved, rErr := engine.ResolveAndAuthorize("minify_js", normPath); rErr != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("Error: %v", rErr)), nil
+		} else {
+			normPath = resolved
+		}
+
 		// Validate file exists and is a file
 		info, err := os.Stat(normPath)
 		if err != nil {
@@ -116,6 +125,12 @@ func registerMinifyTools(reg *toolRegistry) {
 			// Validate the output path is also allowed
 			if !engine.IsPathAllowed(target) {
 				return mcp.NewToolResultError(fmt.Sprintf("Error: output_path %s is not in allowed paths", target)), nil
+			}
+			// TOCTOU defense: re-resolve + re-authorize the canonical output target
+			if resolved, rErr := engine.ResolveAndAuthorize("minify_js", target); rErr != nil {
+				return mcp.NewToolResultError(fmt.Sprintf("Error: %v", rErr)), nil
+			} else {
+				target = resolved
 			}
 		}
 


### PR DESCRIPTION
## Summary
This PR hardens security across three critical areas: closes time-of-check-time-of-use (TOCTOU) windows in file I/O operations, adds input validation to prevent git argument injection and DoS attacks, and fixes path traversal vulnerabilities in backup file access.

## Key Changes

### 1. TOCTOU Defense in File Operations (core/engine.go)
- Added `ResolveAndAuthorize()` method that re-resolves symlinks and re-validates the canonical target immediately before disk I/O
- Integrated into `ReadFileContent()` and `WriteFileContent()` to prevent symlink swapping attacks after initial `IsPathAllowed()` check
- Unlike `ResolveSymlinks()` (used by rename/copy), this permits legitimate symlinks that resolve to allowed paths, closing the window where an attacker could swap a path for a symlink pointing outside the sandbox between authorization and syscall
- Also applied to minify tool operations (tools_minify.go)

### 2. Git Argument Injection Prevention (tools_git.go)
- Added `rejectOptionLike()` helper that guards against git option injection
- User-supplied revisions, branch names, and source parameters are now validated to reject values starting with "-"
- Applied to `gitDiff()` (commit_range), `gitRestore()` (source), and `gitBranch()` (branch_name)
- Prevents attackers from injecting git options (e.g., `--output=<file>`) via positional arguments

### 3. Dashboard Security Hardening (cmd/dashboard/main.go)
- Added `maxSearchQueryLen` constant (256 chars) to bound per-request CPU/allocation work against trivial DoS
- Enforced query length validation in `backupSearchHandler()` and `backupContentSearchHandler()`
- Added configurable `--host` flag (default: 127.0.0.1) with warning when binding to 0.0.0.0
- Removed wildcard `Access-Control-Allow-Origin` header from SSE endpoint to prevent cross-origin reads of live operations stream

### 4. Backup File Path Traversal Fix (cmd/dashboard/main.go)
- Fixed path traversal vulnerability in `backupContentSearchHandler()` where `f.BackupPath` from backup metadata could escape the backup directory
- Added validation using `filepath.Rel()` to ensure resolved path stays within the backup directory
- Rejects paths like `../../etc/passwd` or absolute paths before reading

### 5. Symlink Resolution Bug Fix (core/path_security.go)
- Fixed `ResolveSymlinks()` to record path components before testing parent existence
- Prevents dropping the deepest non-existent component from the result, ensuring correct path resolution for new files

## Implementation Details
- `ResolveAndAuthorize()` uses existing `ResolveSymlinks()` and `IsPathAllowed()` infrastructure, maintaining consistency with access control policy
- TOCTOU fixes operate on the resolved canonical path for all subsequent syscalls, preventing redirection
- Input validation is applied at tool entry points before values reach git/shell execution
- Path traversal checks use `filepath.Rel()` with explicit rejection of `..` components

https://claude.ai/code/session_014rnsz7LmHSkh5ihAJFW2Xf