### PR TITLE
chore: bump version to v4.5.9

### DIFF
--- a/help_content.go
+++ b/help_content.go
@@ -11,7 +11,7 @@ func getHelpContent(topic string, compactMode bool) string {
 
 	switch topic {
 	case "overview":
-		sb.WriteString(`# MCP Filesystem Ultra v4.5.0 - Quick Start
+		sb.WriteString(`# MCP Filesystem Ultra v4.5.9 - Quick Start
 
 ## CRITICAL RULE
 Always use MCP tools (read_file, write_file, edit_file) instead of native file tools.

--- a/main.go
+++ b/main.go
@@ -96,7 +96,7 @@ func main() {
 	flag.Parse()
 
 	if *version {
-		fmt.Printf("MCP Filesystem Server Ultra-Fast v4.5.0\n")
+		fmt.Printf("MCP Filesystem Server Ultra-Fast v4.5.9\n")
 		fmt.Printf("Protocol: MCP 2025-11-25\n")
 		fmt.Printf("Build: %s\n", time.Now().Format("2006-01-02"))
 		fmt.Printf("Go: %s\n", runtime.Version())
@@ -153,7 +153,7 @@ func main() {
 	// Setup logging
 	setupLogging(config)
 
-	log.Printf("Starting MCP Filesystem Server Ultra-Fast v4.5.0")
+	log.Printf("Starting MCP Filesystem Server Ultra-Fast v4.5.9")
 	log.Printf("Config: Cache=%s, Parallel=%d, Binary=%s, VSCode=%v, Compact=%v",
 		formatSize(config.CacheSize), config.ParallelOps,
 		formatSize(config.BinaryThreshold), config.VSCodeAPIEnabled, config.CompactMode)


### PR DESCRIPTION
## Summary

Sync the user-facing version strings to v4.5.9 so `--version`, the startup log line, and the `help` content "Quick Start" header all match the CHANGELOG entry for v4.5.9 (singleflight read dedup + ReadFileRange cache path, merged in #14).

## Change

| File | Before | After |
|------|--------|-------|
| `main.go:99` (`--version` output) | `v4.5.0` | `v4.5.9` |
| `main.go:156` (startup log) | `v4.5.0` | `v4.5.9` |
| `help_content.go:14` (`help` tool quick start) | `v4.5.0` | `v4.5.9` |

## Verified

```
$ ./bin/filesystem-ultra-v4.exe --version
MCP Filesystem Server Ultra-Fast v4.5.9
Protocol: MCP 2025-11-25
Build: 2026-06-10
```

## Not touched (intentionally)

- `CHANGELOG.md` historical `4.5.0` section (line 423) — that's a release record, must stay
- `edit_diff_test.go:123` — uses `const Version = "1.0"` as an edit-fixture, unrelated to app version
- `.github/workflows/release.yml` — example tag name in a comment, not the runtime version
- `.claude/skills/...` — the skill catalog metadata is updated separately; flag if you want it included in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)