### PR TITLE
fix(delete_file): integrate soft-delete with BackupManager (issue #16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 # CHANGELOG - MCP Filesystem Server Ultra-Fast
 
+## [Unreleased / 4.5.11] - 2026-06-11
+
+### Reliability — `delete_file` (soft-delete) backup integration (bug 2026-06-11, issue #16)
+
+`delete_file` in soft-delete mode (the default) used a parallel `filesdelete/` mechanism that was **not integrated with the main `BackupManager`**. The response gave no path, no ID, and no restore command, and `backup action:list/restore` did not see soft-deletes. This caused a real data-loss scare on 2026-06-11 where two files from a .NET project were soft-deleted and ended up at `C:\temp\__REPOS\...` (the `hasProjectIndicators()` walk-up does not include `.csproj`/`.sln`, so it walked all the way to `C:\temp\`). The user could not find the files because the response gave no path.
+
+**Fix (issue #16):**
+- When `--backup-dir` is configured, soft-deletes go to `<backup-dir>/filesdelete/<sd-id>/<basename>` with a `metadata.json` sidecar (discoverable, owner-only `0700` permissions, SHA-256 hash for integrity).
+- The response now includes the SD-ID, the trash path, and a one-line restore command.
+- AI can restore via `backup(action:"restore_trash", sd_id:"sd-...")` even when the trash directory is outside the allowed paths.
+- AI can enumerate via `backup(action:"list_trash", filter_path:"...", older_than_days:N)`.
+- AI can permanently clean up via `backup(action:"purge_trash", older_than_days:N)`.
+- Without `--backup-dir`, the legacy walk-up behavior is preserved (with a deprecation warning) so users who don't pass `--backup-dir` are not broken.
+
+**Audit:** the audit log now records `sd_id` for each soft-delete so the dashboard can show them in a future UI iteration.
+
+**Files changed:**
+
+| File | Change |
+|------|--------|
+| `core/backup_manager.go` | +`SoftDeleteInfo` struct, +`SoftDeleteFile`/`ListTrash`/`RestoreTrash`/`PurgeTrash` methods, +`generateSoftDeleteID`/`sanitizeSoftDeleteID`/`hashFile` helpers; `sanitizeBackupID` refactored to delegate to shared `sanitizeID(id, kindLabel)` |
+| `core/file_operations.go` | `SoftDeleteFile` signature changed to `(*SoftDeleteInfo, error)`; delegates to `BackupManager` when `--backup-dir` is set; falls back to legacy walk-up (with `slog.Warn` deprecation warning) otherwise |
+| `core/pipeline.go` | pipeline `delete` action updated to the new signature |
+| `core/audit_logger.go` | +`SDID` field on `AuditEntry` (json `sd_id,omitempty`); +`SetSoftDeleteID` helper |
+| `tools_files.go` | `delete_file` response now includes SD-ID, dest path, and restore command (compact + verbose formats; batch path emits per-file SD-IDs); new `formatSoftDeleteLine`/`formatSoftDeleteCompact`/`formatSoftDeleteVerbose` helpers |
+| `tools_batch.go` | `backup` tool gains 3 actions: `list_trash`, `restore_trash`, `purge_trash`; tool description updated; new `sd_id` parameter; error message updated |
+| `cmd/dashboard/main.go` | mirror `AuditEntry` struct gains `SDID` field (no UI change in this PR) |
+| `tests/softdelete_backupdir_test.go` | NEW — `TestSoftDeleteUsesBackupDir` (verifies new path layout + metadata.json) |
+| `tests/softdelete_response_test.go` | NEW — `TestSoftDeleteReturnsSoftDeleteInfo`, `TestSoftDeleteLegacyReturnsInfoWithEmptySDID` |
+| `tests/trash_restore_test.go` | NEW — `TestBackupRestoreTrash`, `TestRestoreTrashRejectsPathTraversal`, `TestRestoreTrashRefusesIfOriginalPathExists` |
+| `tests/trash_list_test.go` | NEW — `TestBackupListTrash` (all/filter/limit) |
+| `tests/trash_purge_test.go` | NEW — `TestBackupPurgeTrash` (dry-run + real), `TestBackupPurgeTrashRespectsCutoff` |
+| `tests/root_delete_test.go` | extended with `TestSoftDeleteFallsBackWhenNoBackupDir` (legacy path preserved) |
+
+**Out of scope (follow-ups):**
+- Dashboard UI for the trash tab (with search, restore, purge buttons)
+- Cross-volume rename fallback (`io.Copy` + `os.Remove` when `os.Rename` returns `EXDEV`)
+- Auto-migration of legacy `filesdelete/` data left over from before this fix (the user's incident data at `C:\temp\__REPOS\...` is left in place — they have the path)
+- `hasProjectIndicators()` `.csproj`/`.sln`/`.cs` additions (no longer needed because `--backup-dir` controls the location)
+
 ## [Unreleased / 4.5.10] - 2026-06-11
 
 ### Security / Safety — `edit_file` rewrite guard (bug 2026-06-11)

--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -786,6 +786,8 @@ type AuditEntry struct {
 	TokensConsumed int64  `json:"tokens_consumed,omitempty"`
 	TokensBaseline int64  `json:"tokens_baseline,omitempty"`
 	TokensSaved    int64  `json:"tokens_saved,omitempty"`
+	// Soft-delete ID (v4.5.2+, issue #16) — populated by delete_file soft mode
+	SDID string `json:"sd_id,omitempty"`
 }
 
 type ToolStats struct {

--- a/core/audit_logger.go
+++ b/core/audit_logger.go
@@ -80,6 +80,18 @@ func SetBackupID(ctx context.Context, backupID, previousBackupID string) {
 	}
 }
 
+// SetSoftDeleteID annotates the audit entry with the soft-delete ID created by
+// this operation. Used by delete_file (soft mode) to make the operation
+// discoverable in the audit log + dashboard (see issue #16, 2026-06-11).
+func SetSoftDeleteID(ctx context.Context, sdID string) {
+	if sdID == "" {
+		return
+	}
+	if entry, ok := ctx.Value(AuditEntryKey{}).(*AuditEntry); ok {
+		entry.SDID = sdID
+	}
+}
+
 // SetIntegrityStatus annotates the audit entry with file integrity verification result.
 func SetIntegrityStatus(ctx context.Context, status, warning string) {
 	if entry, ok := ctx.Value(AuditEntryKey{}).(*AuditEntry); ok {
@@ -150,6 +162,9 @@ type AuditEntry struct {
 	// Backup chain tracking (undo step-through)
 	BackupID         string `json:"backup_id,omitempty"`          // backup created for this edit
 	PreviousBackupID string `json:"previous_backup_id,omitempty"` // parent in undo chain
+
+	// Soft-delete ID (trash tracking) — added in v4.5.2+ (issue #16)
+	SDID string `json:"sd_id,omitempty"` // soft-delete ID created by delete_file
 
 	// File integrity verification (for HIGH/CRITICAL edits)
 	IntegrityStatus string `json:"integrity_status,omitempty"` // "OK", "WARNING", "ERROR"

--- a/core/backup_manager.go
+++ b/core/backup_manager.go
@@ -54,6 +54,19 @@ type RestoreResult struct {
 	PreRestoreID  string              `json:"pre_restore_id,omitempty"`
 }
 
+// SoftDeleteInfo contains information about a soft-deleted file in the trash.
+// Files live at <BackupDir>/filesdelete/<sd-id>/<basename> with a metadata.json
+// sidecar describing the original location and contents.
+type SoftDeleteInfo struct {
+	SDID         string    `json:"sd_id"`         // soft-delete ID (e.g. "sd-20260611-150455-a1b2c3d4")
+	OriginalPath string    `json:"original_path"` // where the file used to live
+	DestPath     string    `json:"dest_path"`     // full path inside the trash
+	Size         int64     `json:"size"`          // bytes
+	Hash         string    `json:"hash"`          // SHA-256 hex of the moved file
+	Timestamp    time.Time `json:"timestamp"`     // when the soft-delete happened
+	Kind         string    `json:"kind"`          // always "soft_delete" (parallels BackupInfo.Operation)
+}
+
 // BackupManager gestiona todos los backups del sistema
 type BackupManager struct {
 	backupDir     string
@@ -293,23 +306,36 @@ func (bm *BackupManager) ListBackups(limit int, filterOperation string, filterPa
 	return results, nil
 }
 
-// sanitizeBackupID validates that a backup ID contains only safe characters
-// to prevent path traversal attacks via malicious backup IDs.
-func sanitizeBackupID(backupID string) error {
-	if backupID == "" {
-		return fmt.Errorf("backup ID cannot be empty")
+// sanitizeID validates that an identifier (backup ID or soft-delete ID) contains
+// only safe characters to prevent path traversal attacks via malicious IDs.
+// kindLabel is used in error messages (e.g. "backup ID", "soft-delete ID").
+func sanitizeID(id, kindLabel string) error {
+	if id == "" {
+		return fmt.Errorf("%s cannot be empty", kindLabel)
 	}
-	// Backup IDs should only contain alphanumeric chars, hyphens, and underscores
-	for _, c := range backupID {
+	// IDs should only contain alphanumeric chars, hyphens, and underscores
+	for _, c := range id {
 		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-' || c == '_') {
-			return fmt.Errorf("invalid backup ID: contains illegal character '%c'", c)
+			return fmt.Errorf("invalid %s: contains illegal character '%c'", kindLabel, c)
 		}
 	}
 	// Also reject if it contains path separators or traversal patterns
-	if strings.Contains(backupID, "..") || strings.ContainsAny(backupID, `/\`) {
-		return fmt.Errorf("invalid backup ID: contains path traversal characters")
+	if strings.Contains(id, "..") || strings.ContainsAny(id, `/\`) {
+		return fmt.Errorf("invalid %s: contains path traversal characters", kindLabel)
 	}
 	return nil
+}
+
+// sanitizeBackupID validates that a backup ID contains only safe characters
+// to prevent path traversal attacks via malicious backup IDs.
+func sanitizeBackupID(backupID string) error {
+	return sanitizeID(backupID, "backup ID")
+}
+
+// sanitizeSoftDeleteID validates a soft-delete ID against the same character set
+// as backup IDs. See sanitizeID for the rules.
+func sanitizeSoftDeleteID(id string) error {
+	return sanitizeID(id, "soft-delete ID")
 }
 
 // GetBackupInfo obtiene información de un backup específico
@@ -867,4 +893,343 @@ func FormatAge(t time.Time) string {
 		return "1 day ago"
 	}
 	return fmt.Sprintf("%d days ago", days)
+}
+
+// ============================================================================
+// Soft-delete (trash) subsystem
+// ============================================================================
+//
+// Soft-deletes are stored at <BackupDir>/filesdelete/<sd-id>/<basename> with a
+// metadata.json sidecar. They are NOT added to BackupManager.metadataCache so
+// the maxBackups cap and cleanupIfNeeded do not touch them. Use PurgeTrash for
+// manual cleanup, or restore via RestoreTrash.
+//
+// This subsystem was added in v4.5.2+ to fix a real bug (2026-06-11) where
+// soft-deletes went to a parallel filesdelete/ folder with no discoverability
+// and no way to restore via MCP tools.
+
+// softDeleteTrashSubdir is the trash subdirectory name under BackupDir.
+const softDeleteTrashSubdir = "filesdelete"
+
+// SoftDeleteFile moves a file to the trash under <BackupDir>/filesdelete/<sd-id>/<basename>
+// and writes a metadata.json sidecar with the original path, size, and hash.
+// Returns a SoftDeleteInfo that the caller (engine) can use to format a
+// response with a restore command.
+//
+// The path is expected to have been validated by the caller (IsPathAllowed +
+// ResolveAndAuthorize). The backup manager does NOT do another full path
+// validation — it does a basic filepath.Clean check and refuses path-traversal
+// attempts in metadata fields.
+//
+// On error after the move, the file may be left in the trash with no metadata.
+// Callers should treat SoftDeleteFile failures as "delete did not happen" and
+// surface the error to the user.
+func (bm *BackupManager) SoftDeleteFile(path string) (*SoftDeleteInfo, error) {
+	bm.mutex.Lock()
+	defer bm.mutex.Unlock()
+
+	if bm.backupDir == "" {
+		return nil, fmt.Errorf("backup directory not configured; cannot soft-delete")
+	}
+
+	// Reject any path-traversal attempt in the input even though the engine
+	// already validated. Defense in depth.
+	cleanPath := filepath.Clean(path)
+	if strings.Contains(cleanPath, "..") {
+		return nil, fmt.Errorf("invalid path: contains '..'")
+	}
+
+	// Stat the source so we can record size + mtime.
+	fileInfo, err := os.Stat(cleanPath)
+	if err != nil {
+		return nil, fmt.Errorf("source file not found: %w", err)
+	}
+	if fileInfo.IsDir() {
+		return nil, fmt.Errorf("cannot soft-delete a directory: %s", cleanPath)
+	}
+
+	// Generate SD-ID and prepare the per-deletion directory.
+	sdID := generateSoftDeleteID()
+	trashRoot := filepath.Join(bm.backupDir, softDeleteTrashSubdir)
+	sdDir := filepath.Join(trashRoot, sdID)
+	if err := os.MkdirAll(sdDir, 0700); err != nil {
+		return nil, fmt.Errorf("failed to create trash directory: %w", err)
+	}
+
+	destPath := filepath.Join(sdDir, filepath.Base(cleanPath))
+
+	// If destPath already exists (extremely rare — same basename in same second
+	// from two soft-deletes), suffix the basename with a short hash of the source
+	// path. Avoids collision without needing a retry loop.
+	if _, err := os.Stat(destPath); err == nil {
+		ext := filepath.Ext(destPath)
+		name := destPath[:len(destPath)-len(ext)]
+		shortHash := fmt.Sprintf("%x", sha256.Sum256([]byte(cleanPath+sdID)))[:8]
+		destPath = fmt.Sprintf("%s_%s%s", name, shortHash, ext)
+	}
+
+	// Atomic move (same-volume); fails on cross-volume (EXDEV) — caller can
+	// fall back to copy+remove in a follow-up.
+	if err := os.Rename(cleanPath, destPath); err != nil {
+		// Clean up the empty trash subdir we just created.
+		_ = os.Remove(sdDir)
+		return nil, fmt.Errorf("failed to move file to trash: %w", err)
+	}
+
+	// Compute hash of the moved file for integrity verification on restore.
+	hash, err := hashFile(destPath)
+	if err != nil {
+		// Move succeeded but hash failed — file is in trash, metadata is partial.
+		// Log loudly; the metadata write below will still record what we have.
+		slog.Warn("Failed to hash soft-deleted file", "path", destPath, "error", err)
+	}
+
+	info := &SoftDeleteInfo{
+		SDID:         sdID,
+		OriginalPath: cleanPath,
+		DestPath:     destPath,
+		Size:         fileInfo.Size(),
+		Hash:         hash,
+		Timestamp:    time.Now(),
+		Kind:         "soft_delete",
+	}
+
+	// Write metadata sidecar. If this fails, the file is in the trash but
+	// undiscoverable. Log + return error so the caller knows restore is blocked.
+	if err := bm.saveSoftDeleteMetadata(sdDir, info); err != nil {
+		return info, fmt.Errorf("file moved to trash but metadata write failed: %w", err)
+	}
+
+	return info, nil
+}
+
+// ListTrash enumerates soft-deleted files in the trash, optionally filtered by
+// substring match against OriginalPath and minimum age in days. limit <= 0
+// means no limit.
+func (bm *BackupManager) ListTrash(limit int, filterPath string, olderThanDays int) ([]SoftDeleteInfo, error) {
+	bm.mutex.RLock()
+	defer bm.mutex.RUnlock()
+
+	if bm.backupDir == "" {
+		return nil, nil
+	}
+
+	trashRoot := filepath.Join(bm.backupDir, softDeleteTrashSubdir)
+	entries, err := os.ReadDir(trashRoot)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read trash directory: %w", err)
+	}
+
+	cutoff := time.Time{}
+	if olderThanDays > 0 {
+		cutoff = time.Now().AddDate(0, 0, -olderThanDays)
+	}
+
+	results := make([]SoftDeleteInfo, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		sdDir := filepath.Join(trashRoot, entry.Name())
+		metaPath := filepath.Join(sdDir, "metadata.json")
+		data, err := os.ReadFile(metaPath)
+		if err != nil {
+			slog.Warn("Skipping trash entry with unreadable metadata", "sd_id", entry.Name(), "error", err)
+			continue
+		}
+		var info SoftDeleteInfo
+		if err := json.Unmarshal(data, &info); err != nil {
+			slog.Warn("Skipping trash entry with invalid metadata", "sd_id", entry.Name(), "error", err)
+			continue
+		}
+
+		// Apply filters
+		if filterPath != "" {
+			haystack := strings.ToLower(info.OriginalPath)
+			needle := strings.ToLower(filterPath)
+			if !strings.Contains(haystack, needle) {
+				continue
+			}
+		}
+		if !cutoff.IsZero() && info.Timestamp.After(cutoff) {
+			continue
+		}
+
+		results = append(results, info)
+	}
+
+	// Newest first
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].Timestamp.After(results[j].Timestamp)
+	})
+
+	if limit > 0 && len(results) > limit {
+		results = results[:limit]
+	}
+
+	return results, nil
+}
+
+// RestoreTrash moves a soft-deleted file back to its original path. The
+// original directory is created if missing. Returns the restored original path.
+//
+// Validates the SD-ID against path traversal and confirms the recorded
+// DestPath is actually inside our known trash root (defense against metadata
+// tampering).
+func (bm *BackupManager) RestoreTrash(sdID string) (string, error) {
+	if err := sanitizeSoftDeleteID(sdID); err != nil {
+		return "", err
+	}
+
+	bm.mutex.Lock()
+	defer bm.mutex.Unlock()
+
+	if bm.backupDir == "" {
+		return "", fmt.Errorf("backup directory not configured; cannot restore from trash")
+	}
+
+	trashRoot := filepath.Join(bm.backupDir, softDeleteTrashSubdir)
+	sdDir := filepath.Join(trashRoot, sdID)
+	metaPath := filepath.Join(sdDir, "metadata.json")
+	data, err := os.ReadFile(metaPath)
+	if err != nil {
+		return "", fmt.Errorf("trash entry not found: %s", sdID)
+	}
+
+	var info SoftDeleteInfo
+	if err := json.Unmarshal(data, &info); err != nil {
+		return "", fmt.Errorf("invalid trash metadata: %w", err)
+	}
+
+	// Defense: confirm DestPath is inside trashRoot (defense against metadata
+	// tampering or copy-paste of an SD-ID pointing elsewhere).
+	absTrashRoot, err := filepath.Abs(trashRoot)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve trash root: %w", err)
+	}
+	absDest, err := filepath.Abs(info.DestPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve dest path: %w", err)
+	}
+	if !strings.HasPrefix(strings.ToLower(absDest), strings.ToLower(absTrashRoot)+string(os.PathSeparator)) {
+		return "", fmt.Errorf("trash metadata points outside trash root: %s", info.DestPath)
+	}
+
+	// Confirm the file still exists in the trash
+	if _, err := os.Stat(info.DestPath); err != nil {
+		return "", fmt.Errorf("trash file missing: %w", err)
+	}
+
+	// Ensure the original directory exists (it may have been removed since)
+	if err := os.MkdirAll(filepath.Dir(info.OriginalPath), 0755); err != nil {
+		return "", fmt.Errorf("failed to recreate original directory: %w", err)
+	}
+
+	// If the original path now has a file (user re-created it), refuse — do
+	// not silently overwrite.
+	if _, err := os.Stat(info.OriginalPath); err == nil {
+		return "", fmt.Errorf("original path already exists; cannot overwrite: %s", info.OriginalPath)
+	}
+
+	if err := os.Rename(info.DestPath, info.OriginalPath); err != nil {
+		return "", fmt.Errorf("failed to move file back: %w", err)
+	}
+
+	// Remove the now-empty sd-id subdir + metadata.json (best-effort).
+	_ = os.Remove(metaPath)
+	_ = os.Remove(sdDir)
+
+	return info.OriginalPath, nil
+}
+
+// PurgeTrash permanently removes trash entries older than olderThanDays.
+// Returns (deletedCount, freedBytes, error). If dryRun is true, no files are
+// removed; the returned counts reflect what WOULD be removed.
+func (bm *BackupManager) PurgeTrash(olderThanDays int, dryRun bool) (int, int64, error) {
+	bm.mutex.Lock()
+	defer bm.mutex.Unlock()
+
+	if bm.backupDir == "" {
+		return 0, 0, nil
+	}
+
+	trashRoot := filepath.Join(bm.backupDir, softDeleteTrashSubdir)
+	entries, err := os.ReadDir(trashRoot)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, 0, nil
+		}
+		return 0, 0, fmt.Errorf("failed to read trash directory: %w", err)
+	}
+
+	cutoff := time.Now().AddDate(0, 0, -olderThanDays)
+	deletedCount := 0
+	var freedBytes int64
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		sdDir := filepath.Join(trashRoot, entry.Name())
+		metaPath := filepath.Join(sdDir, "metadata.json")
+		data, err := os.ReadFile(metaPath)
+		if err != nil {
+			continue
+		}
+		var info SoftDeleteInfo
+		if err := json.Unmarshal(data, &info); err != nil {
+			continue
+		}
+		if !info.Timestamp.Before(cutoff) {
+			continue
+		}
+
+		freedBytes += info.Size
+		deletedCount++
+
+		if !dryRun {
+			if err := os.RemoveAll(sdDir); err != nil {
+				slog.Warn("Failed to purge trash entry", "sd_id", entry.Name(), "error", err)
+				deletedCount--
+				freedBytes -= info.Size
+			}
+		}
+	}
+
+	return deletedCount, freedBytes, nil
+}
+
+// saveSoftDeleteMetadata writes a SoftDeleteInfo as JSON to <sdDir>/metadata.json
+// with 0600 permissions (owner-only read, owner-only write).
+func (bm *BackupManager) saveSoftDeleteMetadata(sdDir string, info *SoftDeleteInfo) error {
+	data, err := json.MarshalIndent(info, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(sdDir, "metadata.json"), data, 0600)
+}
+
+// generateSoftDeleteID returns a unique soft-delete ID in the form
+// "sd-<YYYYMMDD-HHMMSS>-<16 hex chars>". Reuses the algorithm from
+// generateBackupID but with a "sd-" prefix for grep-ability and namespace
+// separation.
+func generateSoftDeleteID() string {
+	return "sd-" + generateBackupID()
+}
+
+// hashFile computes the SHA-256 hex digest of a single file's contents.
+func hashFile(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	hash := sha256.New()
+	if _, err := io.Copy(hash, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(hash.Sum(nil)), nil
 }

--- a/core/file_operations.go
+++ b/core/file_operations.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -75,13 +76,23 @@ func (e *UltraFastEngine) RenameFile(ctx context.Context, oldPath, newPath strin
 	return nil
 }
 
-// SoftDeleteFile moves a file to a "filesdelete" folder for later deletion
-func (e *UltraFastEngine) SoftDeleteFile(ctx context.Context, path string) error {
+// SoftDeleteFile moves a file to the trash and returns a SoftDeleteInfo so the
+// caller (tool handler) can format a response with the SD-ID, dest path, and a
+// restore command.
+//
+// When --backup-dir is configured AND a BackupManager is available, the file
+// goes to <BackupDir>/filesdelete/<sd-id>/<basename> with a metadata.json
+// sidecar (the discoverable path; AI can restore via backup(action:"restore_trash")).
+//
+// When --backup-dir is NOT configured, the legacy walk-up behavior is used
+// (with a deprecation warning) so users who don't pass --backup-dir are not
+// broken. Legacy entries are NOT discoverable via backup(action:"list_trash").
+func (e *UltraFastEngine) SoftDeleteFile(ctx context.Context, path string) (*SoftDeleteInfo, error) {
 	// Normalize path (handles WSL ↔ Windows conversion)
 	path = NormalizePath(path)
 	// Acquire semaphore
 	if err := e.acquireOperation(ctx, "softdelete"); err != nil {
-		return err
+		return nil, err
 	}
 
 	start := time.Now()
@@ -89,16 +100,16 @@ func (e *UltraFastEngine) SoftDeleteFile(ctx context.Context, path string) error
 
 	// Check if path is allowed (security + access control)
 	if !e.IsPathAllowed(path) {
-		return fmt.Errorf("access denied: path '%s' is not in allowed paths", path)
+		return nil, fmt.Errorf("access denied: path '%s' is not in allowed paths", path)
 	}
 	// Prevent soft-deletion of allowed-path roots (would move entire tree to trash)
 	if len(e.config.AllowedPaths) > 0 && e.IsAllowedPathRoot(path) {
-		return fmt.Errorf("access denied: cannot delete allowed-path root '%s'", path)
+		return nil, fmt.Errorf("access denied: cannot delete allowed-path root '%s'", path)
 	}
 
 	// Check if source exists
 	if _, err := os.Stat(path); os.IsNotExist(err) {
-		return fmt.Errorf("file does not exist: %s", path)
+		return nil, fmt.Errorf("file does not exist: %s", path)
 	}
 
 	// Execute pre-delete hook
@@ -112,23 +123,66 @@ func (e *UltraFastEngine) SoftDeleteFile(ctx context.Context, path string) error
 		WorkingDir: workingDir,
 	}
 	if _, err := e.hookManager.ExecuteHooks(ctx, HookPreDelete, hookCtx); err != nil {
-		return fmt.Errorf("pre-delete hook denied operation: %w", err)
+		return nil, fmt.Errorf("pre-delete hook denied operation: %w", err)
 	}
 
+	var info *SoftDeleteInfo
+	var err error
+	if e.config.BackupDir != "" && e.backupManager != nil {
+		// Preferred path: delegate to BackupManager for the discoverable trash layout.
+		info, err = e.backupManager.SoftDeleteFile(path)
+	} else {
+		// Legacy fallback: walk-up heuristic. Kept so users without --backup-dir
+		// are not broken by the upgrade. Emits a deprecation warning.
+		info, err = e.softDeleteLegacy(ctx, path)
+	}
+	if err != nil {
+		return info, err
+	}
+
+	// Invalidate cache entries (the source path is gone now)
+	e.invalidateFileReadCache(path)
+	e.cache.InvalidateDirectory(filepath.Dir(path))
+
+	// Execute post-delete hook (best-effort) — include sd_id and dest_path in
+	// metadata so custom hooks can match on them.
+	hookCtx.Event = HookPostDelete
+	hookCtx.Metadata = map[string]interface{}{
+		"dest_path": info.DestPath,
+		"sd_id":     info.SDID,
+	}
+	_, _ = e.hookManager.ExecuteHooks(ctx, HookPostDelete, hookCtx)
+
+	return info, nil
+}
+
+// softDeleteLegacy is the pre-v4.5.2 soft-delete behavior: walk up the path
+// looking for project indicators, drop the file into a "filesdelete/" folder
+// near the project root, and synthesize a SoftDeleteInfo. Kept as a fallback
+// when --backup-dir is not configured so existing setups are not broken.
+//
+// Entries created by this path are NOT discoverable via BackupManager.ListTrash
+// and CANNOT be restored via BackupManager.RestoreTrash (the response hint
+// points the user to a manual move_file instead).
+func (e *UltraFastEngine) softDeleteLegacy(ctx context.Context, path string) (*SoftDeleteInfo, error) {
+	slog.Warn("soft-delete using legacy walk-up location; pass --backup-dir to control trash location and enable restore_trash",
+		"path", path,
+		"hint", "set --backup-dir=/path/to/dir to get a discoverable trash layout")
+
 	// Determine the root directory (where to create filesdelete folder)
-	// If we have allowed paths, use the first one, otherwise use the parent of the file
 	var rootDir string
 	if len(e.config.AllowedPaths) > 0 {
 		rootDir = e.config.AllowedPaths[0]
 	} else {
-		// Find a reasonable root directory - go up until we find a directory that looks like a project root
+		// Find a reasonable root directory - go up until we find a directory that
+		// looks like a project root. Note: this is known to misbehave for
+		// ecosystems not covered by hasProjectIndicators (.NET, PHP, etc.).
 		rootDir = filepath.Dir(path)
 		for {
 			parent := filepath.Dir(rootDir)
 			if parent == rootDir { // reached root
 				break
 			}
-			// Look for common project indicators
 			if hasProjectIndicators(rootDir) {
 				break
 			}
@@ -139,18 +193,18 @@ func (e *UltraFastEngine) SoftDeleteFile(ctx context.Context, path string) error
 	// Create the filesdelete directory
 	deleteDir := filepath.Join(rootDir, "filesdelete")
 	if err := os.MkdirAll(deleteDir, 0755); err != nil {
-		return fmt.Errorf("failed to create filesdelete directory: %w", err)
+		return nil, fmt.Errorf("failed to create filesdelete directory: %w", err)
 	}
 
 	// Create destination path maintaining relative structure
 	absPath, err := filepath.Abs(path)
 	if err != nil {
-		return fmt.Errorf("failed to get absolute path: %w", err)
+		return nil, fmt.Errorf("failed to get absolute path: %w", err)
 	}
 
 	absRootDir, err := filepath.Abs(rootDir)
 	if err != nil {
-		return fmt.Errorf("failed to get absolute root directory: %w", err)
+		return nil, fmt.Errorf("failed to get absolute root directory: %w", err)
 	}
 
 	relPath, err := filepath.Rel(absRootDir, absPath)
@@ -166,7 +220,7 @@ func (e *UltraFastEngine) SoftDeleteFile(ctx context.Context, path string) error
 	// Ensure destination directory exists
 	destDir := filepath.Dir(destPath)
 	if err := os.MkdirAll(destDir, 0755); err != nil {
-		return fmt.Errorf("failed to create destination directory in filesdelete: %w", err)
+		return nil, fmt.Errorf("failed to create destination directory in filesdelete: %w", err)
 	}
 
 	// If destination already exists, add timestamp suffix
@@ -177,21 +231,29 @@ func (e *UltraFastEngine) SoftDeleteFile(ctx context.Context, path string) error
 		destPath = nameWithoutExt + timestamp + ext
 	}
 
-	// Move the file
-	if err := os.Rename(path, destPath); err != nil {
-		return fmt.Errorf("failed to move file to filesdelete: %w", err)
+	// Stat source for size
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("source file not found: %w", err)
 	}
 
-	// Invalidate cache entries
-	e.invalidateFileReadCache(path)
-	e.cache.InvalidateDirectory(filepath.Dir(path))
+	// Move the file
+	if err := os.Rename(path, destPath); err != nil {
+		return nil, fmt.Errorf("failed to move file to filesdelete: %w", err)
+	}
 
-	// Execute post-delete hook (best-effort)
-	hookCtx.Event = HookPostDelete
-	hookCtx.Metadata = map[string]interface{}{"dest_path": destPath}
-	_, _ = e.hookManager.ExecuteHooks(ctx, HookPostDelete, hookCtx)
-
-	return nil
+	// Synthesize a SoftDeleteInfo. SDID is empty — legacy entries are not
+	// discoverable via BackupManager.ListTrash. Kind signals the legacy mode
+	// so the response formatter can show a different hint.
+	return &SoftDeleteInfo{
+		SDID:         "", // no discoverable ID in legacy mode
+		OriginalPath: path,
+		DestPath:     destPath,
+		Size:         fileInfo.Size(),
+		Hash:         "", // no hash in legacy mode
+		Timestamp:    time.Now(),
+		Kind:         "soft_delete_legacy",
+	}, nil
 }
 
 // hasProjectIndicators checks if a directory has common project indicators

--- a/core/pipeline.go
+++ b/core/pipeline.go
@@ -950,7 +950,7 @@ func (pe *PipelineExecutor) executeDelete(ctx context.Context, step PipelineStep
 
 		if !dryRun {
 			// Perform soft delete
-			if err := pe.engine.SoftDeleteFile(ctx, normalizedPath); err != nil {
+			if _, err := pe.engine.SoftDeleteFile(ctx, normalizedPath); err != nil {
 				return &PipelineStepError{
 					StepID:  step.ID,
 					Action:  "delete",

--- a/tests/root_delete_test.go
+++ b/tests/root_delete_test.go
@@ -50,7 +50,7 @@ func TestDeleteAllowedPathRootBlocked(t *testing.T) {
 	}
 
 	// Test 2: soft delete of allowed-path root must fail
-	err = engine.SoftDeleteFile(ctx, allowedDir)
+	_, err = engine.SoftDeleteFile(ctx, allowedDir)
 	if err == nil {
 		t.Fatal("SoftDeleteFile should reject allowed-path root, but it succeeded")
 	}
@@ -125,5 +125,60 @@ func TestDeleteAllowedPathRootVariations(t *testing.T) {
 	// Root must still exist
 	if _, statErr := os.Stat(allowedDir); os.IsNotExist(statErr) {
 		t.Fatal("allowed-path root was deleted via path variation")
+	}
+}
+
+// TestSoftDeleteFallsBackWhenNoBackupDir verifies the legacy walk-up fallback
+// is preserved when --backup-dir is not configured. The behavior change (issue
+// #16) added BackupManager integration as the PREFERRED path; users without
+// --backup-dir should still get the old behavior so they aren't broken.
+func TestSoftDeleteFallsBackWhenNoBackupDir(t *testing.T) {
+	allowedDir := t.TempDir()
+	srcFile := filepath.Join(allowedDir, "no-backup-dir.txt")
+	if err := os.WriteFile(srcFile, []byte("legacy content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cacheSystem, err := cache.NewIntelligentCache(10 * 1024 * 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cacheSystem.Close()
+
+	engine, err := core.NewUltraFastEngine(&core.Config{
+		Cache:        cacheSystem,
+		ParallelOps:  2,
+		AllowedPaths: []string{allowedDir},
+		// BackupDir intentionally empty → legacy walk-up
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer engine.Close()
+
+	ctx := context.Background()
+	info, err := engine.SoftDeleteFile(ctx, srcFile)
+	if err != nil {
+		t.Fatalf("SoftDeleteFile failed: %v", err)
+	}
+
+	// Legacy mode: SDID is empty (not discoverable via backup action)
+	if info.SDID != "" {
+		t.Errorf("legacy mode SDID = %q; want empty", info.SDID)
+	}
+	if info.Kind != "soft_delete_legacy" {
+		t.Errorf("legacy mode Kind = %q; want \"soft_delete_legacy\"", info.Kind)
+	}
+	if info.DestPath == "" {
+		t.Error("legacy mode DestPath is empty; expected a filesdelete/ path")
+	}
+
+	// File is gone from original
+	if _, err := os.Stat(srcFile); !os.IsNotExist(err) {
+		t.Fatal("source file still exists after legacy soft-delete")
+	}
+	// File is in some filesdelete/ folder
+	if _, err := os.Stat(info.DestPath); err != nil {
+		t.Errorf("legacy dest file missing at %s: %v", info.DestPath, err)
 	}
 }

--- a/tests/softdelete_backupdir_test.go
+++ b/tests/softdelete_backupdir_test.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mcp/filesystem-ultra/cache"
+	"github.com/mcp/filesystem-ultra/core"
+)
+
+// TestSoftDeleteUsesBackupDir verifies that when --backup-dir is configured,
+// SoftDeleteFile moves the file to <backup-dir>/filesdelete/<sd-id>/<basename>
+// with a metadata.json sidecar. This is the core fix for issue #16.
+func TestSoftDeleteUsesBackupDir(t *testing.T) {
+	backupDir := t.TempDir()
+	allowedDir := t.TempDir()
+	srcFile := filepath.Join(allowedDir, "important.txt")
+	if err := os.WriteFile(srcFile, []byte("critical content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cacheSystem, err := cache.NewIntelligentCache(10 * 1024 * 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cacheSystem.Close()
+
+	engine, err := core.NewUltraFastEngine(&core.Config{
+		Cache:        cacheSystem,
+		ParallelOps:  2,
+		AllowedPaths: []string{allowedDir},
+		BackupDir:    backupDir,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer engine.Close()
+
+	ctx := context.Background()
+	info, err := engine.SoftDeleteFile(ctx, srcFile)
+	if err != nil {
+		t.Fatalf("SoftDeleteFile failed: %v", err)
+	}
+
+	// SD-ID must be non-empty and well-formed
+	if info.SDID == "" {
+		t.Fatal("SDID is empty; expected a non-empty ID like sd-20260611-150455-a1b2c3d4")
+	}
+	if !strings.HasPrefix(info.SDID, "sd-") {
+		t.Errorf("SDID %q does not start with 'sd-'", info.SDID)
+	}
+
+	// The file must be GONE from the original location
+	if _, err := os.Stat(srcFile); !os.IsNotExist(err) {
+		t.Fatal("source file still exists after SoftDeleteFile")
+	}
+
+	// The file must be in <backup-dir>/filesdelete/<sd-id>/<basename>
+	expectedDir := filepath.Join(backupDir, "filesdelete", info.SDID)
+	if _, err := os.Stat(expectedDir); err != nil {
+		t.Fatalf("expected trash subdir %s: %v", expectedDir, err)
+	}
+	expectedDest := filepath.Join(expectedDir, "important.txt")
+	if _, err := os.Stat(expectedDest); err != nil {
+		t.Fatalf("expected trashed file %s: %v", expectedDest, err)
+	}
+
+	// The metadata.json sidecar must exist and parse
+	metaPath := filepath.Join(expectedDir, "metadata.json")
+	data, err := os.ReadFile(metaPath)
+	if err != nil {
+		t.Fatalf("metadata.json missing: %v", err)
+	}
+	var meta core.SoftDeleteInfo
+	if err := json.Unmarshal(data, &meta); err != nil {
+		t.Fatalf("metadata.json invalid: %v", err)
+	}
+	if meta.OriginalPath != srcFile {
+		t.Errorf("metadata.OriginalPath = %q, want %q", meta.OriginalPath, srcFile)
+	}
+	if meta.DestPath != expectedDest {
+		t.Errorf("metadata.DestPath = %q, want %q", meta.DestPath, expectedDest)
+	}
+	if meta.Size != int64(len("critical content")) {
+		t.Errorf("metadata.Size = %d, want %d", meta.Size, len("critical content"))
+	}
+	if meta.Hash == "" {
+		t.Error("metadata.Hash is empty; expected SHA-256 hex")
+	}
+	if meta.Kind != "soft_delete" {
+		t.Errorf("metadata.Kind = %q, want \"soft_delete\"", meta.Kind)
+	}
+
+	// Trash directory must NOT contain the legacy "filesdelete/__REPOS/..." style path
+	// (which was the bug — file got mis-rooted to C:\temp\__REPOS\...)
+	trashRoot := filepath.Join(backupDir, "filesdelete")
+	walkErr := filepath.Walk(trashRoot, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		// Any path under the trash should be <sd-id>/<basename> or <sd-id>/metadata.json
+		// Never __REPOS or arbitrary deep trees.
+		if info.IsDir() && info.Name() == "__REPOS" {
+			t.Errorf("trash contains __REPOS/ — legacy walk-up path leaked: %s", path)
+		}
+		return nil
+	})
+	if walkErr != nil {
+		t.Fatalf("walk trash failed: %v", walkErr)
+	}
+}

--- a/tests/softdelete_response_test.go
+++ b/tests/softdelete_response_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mcp/filesystem-ultra/cache"
+	"github.com/mcp/filesystem-ultra/core"
+)
+
+// TestSoftDeleteReturnsSoftDeleteInfo verifies that the new SoftDeleteFile
+// signature returns a populated *SoftDeleteInfo so the caller can format a
+// response with a restore command.
+func TestSoftDeleteReturnsSoftDeleteInfo(t *testing.T) {
+	backupDir := t.TempDir()
+	allowedDir := t.TempDir()
+	srcFile := filepath.Join(allowedDir, "doc.go")
+	if err := os.WriteFile(srcFile, []byte("package x\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cacheSystem, err := cache.NewIntelligentCache(10 * 1024 * 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cacheSystem.Close()
+
+	engine, err := core.NewUltraFastEngine(&core.Config{
+		Cache:        cacheSystem,
+		ParallelOps:  2,
+		AllowedPaths: []string{allowedDir},
+		BackupDir:    backupDir,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer engine.Close()
+
+	ctx := context.Background()
+	info, err := engine.SoftDeleteFile(ctx, srcFile)
+	if err != nil {
+		t.Fatalf("SoftDeleteFile failed: %v", err)
+	}
+
+	// All fields the response formatter needs must be populated
+	if info.SDID == "" {
+		t.Error("SDID is empty")
+	}
+	if !strings.HasPrefix(info.SDID, "sd-") {
+		t.Errorf("SDID %q missing 'sd-' prefix", info.SDID)
+	}
+	if info.OriginalPath != srcFile {
+		t.Errorf("OriginalPath = %q, want %q", info.OriginalPath, srcFile)
+	}
+	if info.DestPath == "" {
+		t.Error("DestPath is empty")
+	}
+	if !strings.Contains(info.DestPath, backupDir) {
+		t.Errorf("DestPath %q is not under backup-dir %q", info.DestPath, backupDir)
+	}
+	if info.Size != int64(len("package x\n")) {
+		t.Errorf("Size = %d, want %d", info.Size, len("package x\n"))
+	}
+	if info.Hash == "" {
+		t.Error("Hash is empty; expected SHA-256")
+	}
+	if info.Timestamp.IsZero() {
+		t.Error("Timestamp is zero")
+	}
+	if info.Kind != "soft_delete" {
+		t.Errorf("Kind = %q, want \"soft_delete\"", info.Kind)
+	}
+}
+
+// TestSoftDeleteLegacyReturnsInfoWithEmptySDID verifies the legacy fallback
+// (no --backup-dir) still returns a *SoftDeleteInfo so the response formatter
+// can show a "manual move_file" hint, even though the SD-ID is empty.
+func TestSoftDeleteLegacyReturnsInfoWithEmptySDID(t *testing.T) {
+	allowedDir := t.TempDir()
+	srcFile := filepath.Join(allowedDir, "legacy.txt")
+	if err := os.WriteFile(srcFile, []byte("legacy content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cacheSystem, err := cache.NewIntelligentCache(10 * 1024 * 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cacheSystem.Close()
+
+	engine, err := core.NewUltraFastEngine(&core.Config{
+		Cache:        cacheSystem,
+		ParallelOps:  2,
+		AllowedPaths: []string{allowedDir},
+		// BackupDir intentionally empty → triggers legacy walk-up
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer engine.Close()
+
+	ctx := context.Background()
+	info, err := engine.SoftDeleteFile(ctx, srcFile)
+	if err != nil {
+		t.Fatalf("SoftDeleteFile failed: %v", err)
+	}
+
+	// In legacy mode, SDID is empty (the file is in a parallel filesdelete/ folder
+	// without metadata.json, so it's not discoverable via backup(action:"list_trash")).
+	if info.SDID != "" {
+		t.Errorf("SDID = %q in legacy mode; expected empty (legacy entries are not discoverable)", info.SDID)
+	}
+	if info.DestPath == "" {
+		t.Error("DestPath is empty; legacy mode should still record the trash location")
+	}
+	if info.OriginalPath != srcFile {
+		t.Errorf("OriginalPath = %q, want %q", info.OriginalPath, srcFile)
+	}
+	if info.Kind != "soft_delete_legacy" {
+		t.Errorf("Kind = %q, want \"soft_delete_legacy\"", info.Kind)
+	}
+}

--- a/tests/trash_list_test.go
+++ b/tests/trash_list_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mcp/filesystem-ultra/cache"
+	"github.com/mcp/filesystem-ultra/core"
+)
+
+// TestBackupListTrash verifies that ListTrash enumerates all soft-deleted
+// files and respects the filter_path parameter.
+func TestBackupListTrash(t *testing.T) {
+	backupDir := t.TempDir()
+	allowedDir := t.TempDir()
+
+	// Create three files in two different subdirs
+	files := map[string]string{
+		filepath.Join(allowedDir, "alpha", "a.txt"):   "alpha-a",
+		filepath.Join(allowedDir, "alpha", "b.txt"):   "alpha-b",
+		filepath.Join(allowedDir, "beta", "c.txt"):    "beta-c",
+	}
+	for path, content := range files {
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cacheSystem, err := cache.NewIntelligentCache(10 * 1024 * 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cacheSystem.Close()
+
+	engine, err := core.NewUltraFastEngine(&core.Config{
+		Cache:        cacheSystem,
+		ParallelOps:  2,
+		AllowedPaths: []string{allowedDir},
+		BackupDir:    backupDir,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer engine.Close()
+
+	ctx := context.Background()
+	for path := range files {
+		if _, err := engine.SoftDeleteFile(ctx, path); err != nil {
+			t.Fatalf("SoftDeleteFile(%s) failed: %v", path, err)
+		}
+	}
+
+	// List all — expect 3
+	all, err := engine.GetBackupManager().ListTrash(0, "", 0)
+	if err != nil {
+		t.Fatalf("ListTrash failed: %v", err)
+	}
+	if len(all) != 3 {
+		t.Errorf("ListTrash returned %d entries; want 3", len(all))
+	}
+	for _, e := range all {
+		if e.SDID == "" {
+			t.Error("entry has empty SDID")
+		}
+		if e.OriginalPath == "" {
+			t.Error("entry has empty OriginalPath")
+		}
+	}
+
+	// Filter by "alpha" — expect 2
+	alpha, err := engine.GetBackupManager().ListTrash(0, "alpha", 0)
+	if err != nil {
+		t.Fatalf("ListTrash(alpha) failed: %v", err)
+	}
+	if len(alpha) != 2 {
+		t.Errorf("ListTrash(alpha) returned %d; want 2", len(alpha))
+	}
+	for _, e := range alpha {
+		if !strings.Contains(strings.ToLower(e.OriginalPath), "alpha") {
+			t.Errorf("filter leaked: %s", e.OriginalPath)
+		}
+	}
+
+	// Filter by "c.txt" — expect 1
+	cOnly, err := engine.GetBackupManager().ListTrash(0, "c.txt", 0)
+	if err != nil {
+		t.Fatalf("ListTrash(c.txt) failed: %v", err)
+	}
+	if len(cOnly) != 1 {
+		t.Errorf("ListTrash(c.txt) returned %d; want 1", len(cOnly))
+	}
+	if cOnly[0].OriginalPath != filepath.Join(allowedDir, "beta", "c.txt") {
+		t.Errorf("got %s, want beta/c.txt", cOnly[0].OriginalPath)
+	}
+
+	// Limit — expect at most 2
+	limited, err := engine.GetBackupManager().ListTrash(2, "", 0)
+	if err != nil {
+		t.Fatalf("ListTrash(limit=2) failed: %v", err)
+	}
+	if len(limited) > 2 {
+		t.Errorf("ListTrash(limit=2) returned %d; want <= 2", len(limited))
+	}
+}

--- a/tests/trash_purge_test.go
+++ b/tests/trash_purge_test.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/mcp/filesystem-ultra/cache"
+	"github.com/mcp/filesystem-ultra/core"
+)
+
+// TestBackupPurgeTrash verifies that PurgeTrash removes entries older than
+// the cutoff, and that dry_run doesn't actually delete anything.
+func TestBackupPurgeTrash(t *testing.T) {
+	backupDir := t.TempDir()
+	allowedDir := t.TempDir()
+	srcFile := filepath.Join(allowedDir, "old.txt")
+	if err := os.WriteFile(srcFile, []byte("old content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cacheSystem, err := cache.NewIntelligentCache(10 * 1024 * 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cacheSystem.Close()
+
+	engine, err := core.NewUltraFastEngine(&core.Config{
+		Cache:        cacheSystem,
+		ParallelOps:  2,
+		AllowedPaths: []string{allowedDir},
+		BackupDir:    backupDir,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer engine.Close()
+
+	ctx := context.Background()
+	info, err := engine.SoftDeleteFile(ctx, srcFile)
+	if err != nil {
+		t.Fatalf("SoftDeleteFile failed: %v", err)
+	}
+
+	// Backdate the metadata.json's timestamp field so the entry looks >7 days
+	// old. (PurgeTrash filters by the JSON timestamp, not the file's mtime.)
+	metaPath := filepath.Join(backupDir, "filesdelete", info.SDID, "metadata.json")
+	data, err := os.ReadFile(metaPath)
+	if err != nil {
+		t.Fatalf("read metadata: %v", err)
+	}
+	var meta core.SoftDeleteInfo
+	if err := json.Unmarshal(data, &meta); err != nil {
+		t.Fatalf("unmarshal metadata: %v", err)
+	}
+	meta.Timestamp = time.Now().AddDate(0, 0, -30) // 30 days ago
+	back, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal metadata: %v", err)
+	}
+	if err := os.WriteFile(metaPath, back, 0600); err != nil {
+		t.Fatalf("write metadata: %v", err)
+	}
+
+	// Dry run should report 1, not delete
+	deleted, freed, err := engine.GetBackupManager().PurgeTrash(7, true)
+	if err != nil {
+		t.Fatalf("PurgeTrash dry-run failed: %v", err)
+	}
+	if deleted != 1 {
+		t.Errorf("dry-run deleted = %d, want 1", deleted)
+	}
+	if freed == 0 {
+		t.Error("dry-run freed = 0, want > 0")
+	}
+	if _, err := os.Stat(metaPath); err != nil {
+		t.Errorf("dry-run deleted the file: %v", err)
+	}
+
+	// Real run should actually delete
+	deleted, _, err = engine.GetBackupManager().PurgeTrash(7, false)
+	if err != nil {
+		t.Fatalf("PurgeTrash failed: %v", err)
+	}
+	if deleted != 1 {
+		t.Errorf("real-run deleted = %d, want 1", deleted)
+	}
+	if _, err := os.Stat(metaPath); !os.IsNotExist(err) {
+		t.Errorf("real-run did not delete the file: %v", err)
+	}
+	trashDir := filepath.Join(backupDir, "filesdelete", info.SDID)
+	if _, err := os.Stat(trashDir); !os.IsNotExist(err) {
+		t.Errorf("real-run did not remove trash subdir: %v", err)
+	}
+}
+
+// TestBackupPurgeTrashRespectsCutoff verifies that entries newer than the
+// cutoff are NOT purged.
+func TestBackupPurgeTrashRespectsCutoff(t *testing.T) {
+	backupDir := t.TempDir()
+	allowedDir := t.TempDir()
+	srcFile := filepath.Join(allowedDir, "recent.txt")
+	if err := os.WriteFile(srcFile, []byte("recent"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cacheSystem, err := cache.NewIntelligentCache(10 * 1024 * 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cacheSystem.Close()
+
+	engine, err := core.NewUltraFastEngine(&core.Config{
+		Cache:        cacheSystem,
+		ParallelOps:  2,
+		AllowedPaths: []string{allowedDir},
+		BackupDir:    backupDir,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer engine.Close()
+
+	ctx := context.Background()
+	info, err := engine.SoftDeleteFile(ctx, srcFile)
+	if err != nil {
+		t.Fatalf("SoftDeleteFile failed: %v", err)
+	}
+
+	// metadata.json was written just now — purge with 7-day cutoff must NOT delete it
+	deleted, _, err := engine.GetBackupManager().PurgeTrash(7, false)
+	if err != nil {
+		t.Fatalf("PurgeTrash failed: %v", err)
+	}
+	if deleted != 0 {
+		t.Errorf("purged %d recent entries; want 0", deleted)
+	}
+	metaPath := filepath.Join(backupDir, "filesdelete", info.SDID, "metadata.json")
+	if _, err := os.Stat(metaPath); err != nil {
+		t.Errorf("recent entry was incorrectly purged: %v", err)
+	}
+}

--- a/tests/trash_restore_test.go
+++ b/tests/trash_restore_test.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mcp/filesystem-ultra/cache"
+	"github.com/mcp/filesystem-ultra/core"
+)
+
+// TestBackupRestoreTrash verifies the full soft-delete → restore-trash cycle:
+// the file ends up back at the original path with identical content.
+func TestBackupRestoreTrash(t *testing.T) {
+	backupDir := t.TempDir()
+	allowedDir := t.TempDir()
+	srcFile := filepath.Join(allowedDir, "roundtrip.txt")
+	originalContent := []byte("this must survive the round trip\n")
+	if err := os.WriteFile(srcFile, originalContent, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cacheSystem, err := cache.NewIntelligentCache(10 * 1024 * 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cacheSystem.Close()
+
+	engine, err := core.NewUltraFastEngine(&core.Config{
+		Cache:        cacheSystem,
+		ParallelOps:  2,
+		AllowedPaths: []string{allowedDir},
+		BackupDir:    backupDir,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer engine.Close()
+
+	ctx := context.Background()
+	info, err := engine.SoftDeleteFile(ctx, srcFile)
+	if err != nil {
+		t.Fatalf("SoftDeleteFile failed: %v", err)
+	}
+
+	// File gone from original, present in trash
+	if _, err := os.Stat(srcFile); !os.IsNotExist(err) {
+		t.Fatal("source file still exists after soft-delete")
+	}
+
+	// Restore
+	restoredPath, err := engine.GetBackupManager().RestoreTrash(info.SDID)
+	if err != nil {
+		t.Fatalf("RestoreTrash failed: %v", err)
+	}
+	if restoredPath != srcFile {
+		t.Errorf("restored to %q, want %q", restoredPath, srcFile)
+	}
+
+	// File back at original with identical content
+	got, err := os.ReadFile(srcFile)
+	if err != nil {
+		t.Fatalf("restored file unreadable: %v", err)
+	}
+	if string(got) != string(originalContent) {
+		t.Errorf("content mismatch: got %q, want %q", got, originalContent)
+	}
+
+	// Trash dir for this SD-ID should be gone
+	trashDir := filepath.Join(backupDir, "filesdelete", info.SDID)
+	if _, err := os.Stat(trashDir); !os.IsNotExist(err) {
+		t.Errorf("trash subdir %q still exists after restore: %v", trashDir, err)
+	}
+}
+
+// TestRestoreTrashRejectsPathTraversal verifies the SD-ID is sanitized
+// against path traversal attacks. Without the sanitizeID check, an attacker
+// could pass "../../etc/passwd" and escape the trash root.
+func TestRestoreTrashRejectsPathTraversal(t *testing.T) {
+	backupDir := t.TempDir()
+
+	cacheSystem, err := cache.NewIntelligentCache(10 * 1024 * 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cacheSystem.Close()
+
+	engine, err := core.NewUltraFastEngine(&core.Config{
+		Cache:        cacheSystem,
+		ParallelOps:  2,
+		AllowedPaths: []string{t.TempDir()},
+		BackupDir:    backupDir,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer engine.Close()
+
+	maliciousIDs := []string{
+		"../../etc/passwd",
+		"..\\..\\windows\\system32",
+		"foo/bar",
+		"foo\\bar",
+		"..",
+		".",
+		"", // empty
+		"normal-but-with-;rm",
+	}
+	for _, id := range maliciousIDs {
+		_, err := engine.GetBackupManager().RestoreTrash(id)
+		if err == nil {
+			t.Errorf("RestoreTrash(%q) should have failed but succeeded", id)
+		}
+		if !strings.Contains(strings.ToLower(err.Error()), "invalid") &&
+			!strings.Contains(strings.ToLower(err.Error()), "soft-delete id") {
+			t.Errorf("RestoreTrash(%q) error %q should mention invalid ID", id, err)
+		}
+	}
+}
+
+// TestRestoreTrashRefusesIfOriginalPathExists verifies that RestoreTrash does
+// NOT silently overwrite an existing file at the original path.
+func TestRestoreTrashRefusesIfOriginalPathExists(t *testing.T) {
+	backupDir := t.TempDir()
+	allowedDir := t.TempDir()
+	srcFile := filepath.Join(allowedDir, "shared.txt")
+	if err := os.WriteFile(srcFile, []byte("original"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cacheSystem, err := cache.NewIntelligentCache(10 * 1024 * 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cacheSystem.Close()
+
+	engine, err := core.NewUltraFastEngine(&core.Config{
+		Cache:        cacheSystem,
+		ParallelOps:  2,
+		AllowedPaths: []string{allowedDir},
+		BackupDir:    backupDir,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer engine.Close()
+
+	ctx := context.Background()
+	info, err := engine.SoftDeleteFile(ctx, srcFile)
+	if err != nil {
+		t.Fatalf("SoftDeleteFile failed: %v", err)
+	}
+
+	// User re-creates a file at the original location with DIFFERENT content
+	if err := os.WriteFile(srcFile, []byte("NEW CONTENT, NOT TO BE OVERWRITTEN"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Restore should refuse
+	_, err = engine.GetBackupManager().RestoreTrash(info.SDID)
+	if err == nil {
+		t.Fatal("RestoreTrash should have refused to overwrite the existing file")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("error %q should mention \"already exists\"", err)
+	}
+
+	// The user's new file must be intact
+	got, err := os.ReadFile(srcFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "NEW CONTENT, NOT TO BE OVERWRITTEN" {
+		t.Errorf("user's new file was modified: got %q", got)
+	}
+}

--- a/tools_batch.go
+++ b/tools_batch.go
@@ -521,17 +521,19 @@ func registerBatchTools(reg *toolRegistry) {
 		mcp.WithReadOnlyHintAnnotation(false),
 		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithIdempotentHintAnnotation(false),
-		mcp.WithDescription("backup — Manage backups, restore, and undo. Actions: list, info, compare, cleanup, restore, undo_last. "+
-			"Auto-created before every edit_file/multi_edit. Related: edit_file, batch_operations, analyze_operation."),
-		mcp.WithString("action", mcp.Description("Action: list (default), info, compare, cleanup, restore, undo_last")),
+		mcp.WithDescription("backup — Manage backups, restore, and undo. Actions: list, info, compare, cleanup, restore, undo_last, undo_chain, list_trash, restore_trash, purge_trash. "+
+			"Auto-created before every edit_file/multi_edit. Soft-deleted files (delete_file) are managed via list_trash/restore_trash/purge_trash when --backup-dir is set. "+
+			"Related: edit_file, batch_operations, analyze_operation, delete_file."),
+		mcp.WithString("action", mcp.Description("Action: list (default), info, compare, cleanup, restore, undo_last, undo_chain, list_trash, restore_trash, purge_trash")),
 		mcp.WithString("backup_id", mcp.Description("Backup ID (required for info, compare, restore)")),
+		mcp.WithString("sd_id", mcp.Description("Soft-delete ID (required for restore_trash)")),
 		mcp.WithString("file_path", mcp.Description("File path for compare or selective restore")),
 		mcp.WithNumber("limit", mcp.Description("Max backups to return for list (default: 20)")),
 		mcp.WithString("filter_operation", mcp.Description("Filter by operation: edit, delete, batch, all")),
 		mcp.WithString("filter_path", mcp.Description("Filter by file path (substring match)")),
 		mcp.WithNumber("newer_than_hours", mcp.Description("Only backups newer than N hours")),
-		mcp.WithNumber("older_than_days", mcp.Description("For cleanup: delete backups older than N days (default: 7)")),
-		mcp.WithBoolean("dry_run", mcp.Description("For cleanup/restore: preview without executing (default: true for cleanup, false for restore)")),
+		mcp.WithNumber("older_than_days", mcp.Description("For cleanup/purge_trash: delete entries older than N days (default: 7)")),
+		mcp.WithBoolean("dry_run", mcp.Description("For cleanup/restore/purge_trash: preview without executing (default: true for cleanup/purge_trash, false for restore)")),
 		mcp.WithBoolean("preview", mcp.Description("For restore: show diff without restoring (default: false)")),
 	)
 	reg.addTool(backupTool, auditWrap(engine, "backup", func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -925,8 +927,105 @@ func registerBatchTools(reg *toolRegistry) {
 			output.WriteString("\nUse backup(action:\"undo_last\", file_path:\"...\") to step backward\n")
 			return mcp.NewToolResultText(output.String()), nil
 
+		case "list_trash":
+			// Enumerate soft-deleted files in the trash (only works when
+			// --backup-dir is configured; otherwise returns empty).
+			limit := 50
+			filterPath := ""
+			olderThanDays := 0
+			if args, ok := request.Params.Arguments.(map[string]interface{}); ok {
+				if l, ok := args["limit"].(float64); ok {
+					limit = int(l)
+				}
+				if fp, ok := args["filter_path"].(string); ok {
+					filterPath = fp
+				}
+				if od, ok := args["older_than_days"].(float64); ok {
+					olderThanDays = int(od)
+				}
+			}
+
+			entries, err := engine.GetBackupManager().ListTrash(limit, filterPath, olderThanDays)
+			if err != nil {
+				return mcp.NewToolResultError(fmt.Sprintf("Failed to list trash: %v", err)), nil
+			}
+
+			var output strings.Builder
+			output.WriteString(fmt.Sprintf("Trash entries (%d)\n", len(entries)))
+			output.WriteString("---\n\n")
+			for _, entry := range entries {
+				output.WriteString(fmt.Sprintf("# %s\n", entry.SDID))
+				output.WriteString(fmt.Sprintf("   Time: %s (%s)\n", entry.Timestamp.Format("2006-01-02 15:04:05"), core.FormatAge(entry.Timestamp)))
+				output.WriteString(fmt.Sprintf("   Original: %s\n", entry.OriginalPath))
+				output.WriteString(fmt.Sprintf("   Size: %s\n", core.FormatSize(entry.Size)))
+				if entry.Hash != "" {
+					output.WriteString(fmt.Sprintf("   Hash: %s\n", entry.Hash[:12]))
+				}
+				output.WriteString("\n")
+			}
+			if len(entries) == 0 {
+				output.WriteString("No trash entries found.\n")
+				if engine.GetBackupManager().GetBackupDir() == "" {
+					output.WriteString("(Trash is only populated when --backup-dir is configured.)\n")
+				}
+			} else {
+				output.WriteString("Use backup(action:\"restore_trash\", sd_id:\"...\") to restore\n")
+				output.WriteString("Use backup(action:\"purge_trash\", older_than_days:N) to permanently delete old entries\n")
+			}
+			return mcp.NewToolResultText(output.String()), nil
+
+		case "restore_trash":
+			// Restore a soft-deleted file by its SD-ID. Validates the SD-ID
+			// against path-traversal inside the BackupManager.
+			sdID, err := request.RequireString("sd_id")
+			if err != nil {
+				return mcp.NewToolResultError(fmt.Sprintf("sd_id is required: %v", err)), nil
+			}
+
+			restoredPath, err := engine.GetBackupManager().RestoreTrash(sdID)
+			if err != nil {
+				return mcp.NewToolResultError(fmt.Sprintf("Failed to restore: %v", err)), nil
+			}
+
+			var output strings.Builder
+			output.WriteString("Trash restore completed successfully\n\n")
+			output.WriteString(fmt.Sprintf("Restored from trash: %s\n", sdID))
+			output.WriteString(fmt.Sprintf("File: %s\n", restoredPath))
+			return mcp.NewToolResultText(output.String()), nil
+
+		case "purge_trash":
+			// Permanently delete trash entries older than olderThanDays.
+			olderThanDays := 7
+			dryRun := true
+			if args, ok := request.Params.Arguments.(map[string]interface{}); ok {
+				if od, ok := args["older_than_days"].(float64); ok {
+					olderThanDays = int(od)
+				}
+				if dr, ok := args["dry_run"].(bool); ok {
+					dryRun = dr
+				}
+			}
+
+			deletedCount, freedSpace, err := engine.GetBackupManager().PurgeTrash(olderThanDays, dryRun)
+			if err != nil {
+				return mcp.NewToolResultError(fmt.Sprintf("Purge trash failed: %v", err)), nil
+			}
+
+			var output strings.Builder
+			if dryRun {
+				output.WriteString("Dry Run - Preview of trash purge\n\n")
+				output.WriteString(fmt.Sprintf("Would delete: %d trash entry/entries\n", deletedCount))
+				output.WriteString(fmt.Sprintf("Would free: %s\n\n", core.FormatSize(freedSpace)))
+				output.WriteString("Run with dry_run: false to actually purge trash\n")
+			} else {
+				output.WriteString("Trash purge completed\n\n")
+				output.WriteString(fmt.Sprintf("Deleted: %d trash entry/entries\n", deletedCount))
+				output.WriteString(fmt.Sprintf("Freed: %s\n", core.FormatSize(freedSpace)))
+			}
+			return mcp.NewToolResultText(output.String()), nil
+
 		default:
-			return mcp.NewToolResultError(fmt.Sprintf("Unknown action: %s. Valid: list, info, compare, cleanup, restore, undo_last", action)), nil
+			return mcp.NewToolResultError(fmt.Sprintf("Unknown action: %s. Valid: list, info, compare, cleanup, restore, undo_last, undo_chain, list_trash, restore_trash, purge_trash", action)), nil
 		}
 	}))
 }

--- a/tools_files.go
+++ b/tools_files.go
@@ -82,21 +82,27 @@ func registerFileTools(reg *toolRegistry) {
 				successCount := 0
 				for _, p := range paths {
 					p = core.NormalizePath(p)
-					var err error
 					if permanent {
-						err = engine.DeleteFile(ctx, p)
-					} else {
-						err = engine.SoftDeleteFile(ctx, p)
-					}
-					if err != nil {
-						results.WriteString(fmt.Sprintf("FAIL: %s — %v\n", p, err))
-					} else {
-						successCount++
-						if permanent {
-							results.WriteString(fmt.Sprintf("OK: %s deleted\n", p))
-						} else {
-							results.WriteString(fmt.Sprintf("OK: %s soft-deleted\n", p))
+						err := engine.DeleteFile(ctx, p)
+						if err != nil {
+							results.WriteString(fmt.Sprintf("FAIL: %s — %v\n", p, err))
+							continue
 						}
+						successCount++
+						results.WriteString(fmt.Sprintf("OK: %s deleted\n", p))
+					} else {
+						info, err := engine.SoftDeleteFile(ctx, p)
+						if err != nil {
+							results.WriteString(fmt.Sprintf("FAIL: %s — %v\n", p, err))
+							continue
+						}
+						successCount++
+						// Annotate audit with the SD-ID (last one wins for batch — the
+						// tool-level audit entry will only carry the final SD-ID, but
+						// the per-line output preserves all of them for the user).
+						core.SetSoftDeleteID(ctx, info.SDID)
+						results.WriteString(formatSoftDeleteLine(p, info, engine.IsCompactMode()))
+						results.WriteString("\n")
 					}
 				}
 				results.WriteString(fmt.Sprintf("\n%d/%d succeeded", successCount, len(paths)))
@@ -121,14 +127,16 @@ func registerFileTools(reg *toolRegistry) {
 		}
 
 		// Default: soft delete
-		err = engine.SoftDeleteFile(ctx, path)
+		info, err := engine.SoftDeleteFile(ctx, path)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("Error: %v", err)), nil
 		}
+		core.SetSoftDeleteID(ctx, info.SDID)
+
 		if engine.IsCompactMode() {
-			return mcp.NewToolResultText(fmt.Sprintf("OK: %s soft-deleted", path)), nil
+			return mcp.NewToolResultText(formatSoftDeleteCompact(path, info)), nil
 		}
-		return mcp.NewToolResultText(fmt.Sprintf("Successfully moved '%s' to filesdelete folder", path)), nil
+		return mcp.NewToolResultText(formatSoftDeleteVerbose(path, info)), nil
 	}))
 
 	// ============================================================================
@@ -258,4 +266,48 @@ func registerFileTools(reg *toolRegistry) {
 		}
 		return mcp.NewToolResultText(info), nil
 	}))
+}
+
+// formatSoftDeleteLine formats a single line of a batch soft-delete result.
+// Used inside the `paths` JSON batch handler (one line per file).
+func formatSoftDeleteLine(path string, info *core.SoftDeleteInfo, compact bool) string {
+	if info.SDID != "" {
+		return fmt.Sprintf("OK: %s soft-deleted (SD:%s)", path, info.SDID)
+	}
+	return fmt.Sprintf("OK: %s soft-deleted (legacy)", path)
+}
+
+// formatSoftDeleteCompact returns a single-line response for the single-path
+// delete_file tool in compact mode. Includes the SD-ID (or "legacy" marker)
+// and a one-line restore command.
+func formatSoftDeleteCompact(path string, info *core.SoftDeleteInfo) string {
+	if info.SDID != "" {
+		return fmt.Sprintf("D %s | SD:%s | restore: backup(action:\"restore_trash\", sd_id:\"%s\")",
+			path, info.SDID, info.SDID)
+	}
+	return fmt.Sprintf("D %s | legacy | manual: move_file(%s → %s) | hint: set --backup-dir",
+		path, info.DestPath, path)
+}
+
+// formatSoftDeleteVerbose returns a multi-line response for the single-path
+// delete_file tool in verbose mode. Includes the SD-ID (or "legacy" marker),
+// the dest path, and a restore command. When the entry is recoverable via the
+// backup tool, the restore command uses backup(action:"restore_trash"). When
+// it's a legacy entry, the response points to a manual move_file.
+func formatSoftDeleteVerbose(path string, info *core.SoftDeleteInfo) string {
+	if info.SDID != "" {
+		return fmt.Sprintf(
+			"OK: %s soft-deleted\n"+
+				"   SD-ID: %s\n"+
+				"   Trash: %s\n"+
+				"   Restore: backup(action:\"restore_trash\", sd_id:\"%s\")\n"+
+				"   Or manually: move_file(%s → %s)\n",
+			path, info.SDID, info.DestPath, info.SDID, info.DestPath, path)
+	}
+	return fmt.Sprintf(
+		"OK: %s soft-deleted (legacy mode — no discoverable trash)\n"+
+			"   Trash: %s\n"+
+			"   Manual restore: move_file(%s → %s)\n"+
+			"   Hint: set --backup-dir to get a discoverable trash + restore_trash action\n",
+		path, info.DestPath, info.DestPath, path)
 }


### PR DESCRIPTION
Fixes #16

## Bug

`delete_file` in soft-delete mode (the default) used a parallel `filesdelete/` mechanism that was **not integrated with `BackupManager`**. The response gave no path, no ID, and no restore command. `backup action:list/restore` did not see soft-deletes.

This caused a real data-loss scare on 2026-06-11: two files from a .NET project were soft-deleted and ended up at `C:\temp\__REPOS\...` — the `hasProjectIndicators()` walk-up does not include `.csproj`/`.sln`, so it walked all the way to `C:\temp\`. The user could not find the files because the response gave no path.

## Fix

- When `--backup-dir` is configured, soft-deletes go to `<backup-dir>/filesdelete/<sd-id>/<basename>` with a `metadata.json` sidecar (owner-only `0700` perms, SHA-256 hash).
- The response now includes the SD-ID, the trash path, and a one-line restore command.
- AI can restore via `backup(action:"restore_trash", sd_id:"sd-...")` even when the trash directory is outside the allowed paths.
- AI can enumerate via `backup(action:"list_trash", filter_path:"...", older_than_days:N)`.
- AI can permanently clean up via `backup(action:"purge_trash", older_than_days:N)`.
- Without `--backup-dir`, the legacy walk-up behavior is preserved (with a deprecation warning) so users who don't pass `--backup-dir` are not broken.
- The audit log now records `sd_id` for each soft-delete so the dashboard can show them in a future UI iteration.

## Example response

**Single file, verbose:**
```
OK: C:\path\to\foo.razor soft-deleted
   SD-ID: sd-20260611-150455-a1b2c3d4
   Trash: C:\backup-dir\filesdelete\sd-20260611-150455-a1b2c3d4\foo.razor
   Restore: backup(action:"restore_trash", sd_id:"sd-20260611-150455-a1b2c3d4")
   Or manually: move_file(<trash_path> → <original_path>)
```

**Single file, compact:**
```
D foo.razor | SD:sd-20260611-150455-a1b2c3d4 | restore: backup(action:"restore_trash", sd_id:"sd-20260611-150455-a1b2c3d4")
```

## Files changed

| File | Change |
|------|--------|
| `core/backup_manager.go` | +`SoftDeleteInfo` struct, +`SoftDeleteFile`/`ListTrash`/`RestoreTrash`/`PurgeTrash` methods, +`generateSoftDeleteID`/`sanitizeSoftDeleteID`/`hashFile` helpers; `sanitizeBackupID` refactored to delegate to shared `sanitizeID` |
| `core/file_operations.go` | `SoftDeleteFile` signature changed to `(*SoftDeleteInfo, error)`; delegates to `BackupManager` when `--backup-dir` is set; falls back to legacy walk-up (with `slog.Warn` deprecation warning) otherwise |
| `core/pipeline.go` | pipeline `delete` action updated to the new signature |
| `core/audit_logger.go` | +`SDID` field on `AuditEntry` (json `sd_id,omitempty`); +`SetSoftDeleteID` helper |
| `tools_files.go` | `delete_file` response now includes SD-ID, dest path, and restore command (compact + verbose formats; batch path emits per-file SD-IDs); new `formatSoftDeleteLine`/`formatSoftDeleteCompact`/`formatSoftDeleteVerbose` helpers |
| `tools_batch.go` | `backup` tool gains 3 actions: `list_trash`, `restore_trash`, `purge_trash` |
| `cmd/dashboard/main.go` | mirror `AuditEntry` struct gains `SDID` field (no UI change in this PR) |
| `tests/softdelete_backupdir_test.go` | NEW — `TestSoftDeleteUsesBackupDir` |
| `tests/softdelete_response_test.go` | NEW — `TestSoftDeleteReturnsSoftDeleteInfo`, `TestSoftDeleteLegacyReturnsInfoWithEmptySDID` |
| `tests/trash_restore_test.go` | NEW — `TestBackupRestoreTrash`, `TestRestoreTrashRejectsPathTraversal`, `TestRestoreTrashRefusesIfOriginalPathExists` |
| `tests/trash_list_test.go` | NEW — `TestBackupListTrash` (all/filter/limit) |
| `tests/trash_purge_test.go` | NEW — `TestBackupPurgeTrash` (dry-run + real), `TestBackupPurgeTrashRespectsCutoff` |
| `tests/root_delete_test.go` | extended with `TestSoftDeleteFallsBackWhenNoBackupDir` |
| `CHANGELOG.md` | new section under v4.5.11 |

## Verification

```bash
go build -ldflags="-s -w" -trimpath -o filesystem-ultra-v4.exe .
go build -ldflags="-s -w" -trimpath -o dashboard.exe ./cmd/dashboard/
go test -timeout 120s ./tests/...   # 16.6s, all green
```

(`-race` skipped — host has no gcc. The new trash methods acquire the BackupManager mutex so concurrent soft-deletes of the same file are serialized correctly.)

## Out of scope (follow-ups)

- Dashboard UI for the trash tab
- Cross-volume rename fallback (EXDEV)
- Auto-migration of legacy `filesdelete/` data

🤖 Generated with [Claude Code](https://claude.com/claude-code)
