### PR TITLE
fix(multi_edit): accept expected_hash for OCC stale-edit protection (B3, #24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The hooks system (`core/hooks.go`) has had **16 events** since the addition of `
   - `TestHooksExampleJSONIsValid` — parses the file and asserts all 16 events are present
   - `TestHooksTestJSONIsValid` — same for the testing config
   - `TestHooksExampleHasNoDuplicateStructure` — round-trips the JSON to detect trailing junk (the original bug)
+- **`docs-website/.../hooks.md`** — added the `re:` regex pattern type to the Pattern Types list (it was missing from the website copy).
+- **`docs/features/HOOKS.md`** — internal mirror of the website hooks doc, also stuck on 12 events and missing the soft-delete section. Brought in sync, then **deleted** in favor of the website as the single source of truth. `docs/README.md` index entry updated to point at the website.
 
 **Why this matters:** `hooks.example.json` is the primary copy-paste template for users setting up the hooks system. A broken reference file would silently break any new user setup. The regression tests guarantee the example stays valid as the codebase evolves.
 
@@ -25,7 +27,9 @@ The hooks system (`core/hooks.go`) has had **16 events** since the addition of `
 |---|---|
 | `examples/hooks.example.json` | rewritten clean + SD-ID example |
 | `examples/README.md` | mentions `hooks-test.json` + soft-delete snippet |
-| `docs-website/src/content/docs/features/hooks.md` | 12→16 events, new read/search sections, new soft-delete metadata subsection |
+| `docs-website/src/content/docs/features/hooks.md` | 12→16 events, new read/search sections, new soft-delete metadata subsection, regex `re:` pattern added |
+| `docs/features/HOOKS.md` | internal mirror brought in sync, then deleted (unified with website) |
+| `docs/README.md` | hooks index entry redirected to website |
 | `core/hooks.go` | remove unused `event` param in `aggregateResults` |
 | `tests/hooks_examples_test.go` | NEW — 3 regression tests |
 | `CHANGELOG.md` | this entry |
@@ -36,6 +40,31 @@ The hooks system (`core/hooks.go`) has had **16 events** since the addition of `
 go build ./...                                       # clean
 go test -run TestHooks ./tests/...                    # 0.045s, 3 cases green
 go test ./...                                        # full suite green
+```
+
+### multi_edit risk notice — real replacement count + clamped `% of file`
+
+The `multi_edit` risk notice appended to success responses showed `0 replacements` and could print `>100% of file` — both made the notice actively misleading (a caller reading `0 replacements` could conclude the operation was a no-op, when in fact the file had been modified). Reported on 2026-06-13, fixed in this release. See [issue #21](https://github.com/scopweb/mcp-filesystem-go-ultra/issues/21).
+
+**Fix 1 — real replacement count.** `calculateMultiEditImpact` in `core/edit_operations.go` built the `aggregateImpact` from a simulated content run and never assigned `Occurrences`, so `FormatRiskNotice` in `core/impact_analyzer.go` printed the Go zero value (`0`). The fix tracks the per-edit `ReplacementCount` returned by `performIntelligentEdit` and assigns the sum to `aggregateImpact.Occurrences` after the loop, so all three `FormatRiskNotice` call sites (skipped-only, dry_run, main path) see the real value. For 4 applied edits the notice now reads `4 replacements` instead of `0 replacements`.
+
+**Fix 2 — clamp displayed `% of file` at 100.** The honest-scope formula `Σ max(|oldText|,|newText|) / fileSize × 100` is a correct upper bound on bytes touched but can exceed 100% on net insertions (a 6-byte anchor replaced by 600 bytes in a 200-byte file yields 300%). The `change_percentage` JSON field and the internal `RiskLevel` are unchanged — only the *displayed* value in the notice string is clamped, so the magnitude word (`"large edit"` / `"very large edit"`) still encodes severity above the 40%/80% thresholds. The notice now reads `100% of file` in those cases.
+
+**Files changed:**
+
+| File | Change |
+|------|--------|
+| `core/edit_operations.go` | `MultiEdit` accumulates `totalReplacements` from per-edit `ReplacementCount`; assigns to `aggregateImpact.Occurrences` after the loop |
+| `core/impact_analyzer.go` | `FormatRiskNotice` clamps the printed `ChangePercentage` to 100 in the notice string (internal field untouched) |
+| `tests/multi_edit_occurrences_counter_test.go` | NEW — 2 regression tests: real count + clamped percentage |
+| `CHANGELOG.md` | this entry |
+
+**Verification:**
+
+```bash
+go test ./tests/ -run "TestIssue21_" -v            # both pass
+go test ./core/...                                  # full suite green
+go test ./tests/...                                 # full suite green
 ```
 
 ## [Unreleased / 4.5.12] - 2026-06-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,32 @@ go test -run "TestContentHash_|TestExpectedHash_" -v   # all 5 pass
 go test ./...                                            # full suite green
 ```
 
+### multi_edit — accept `expected_hash` (OCC parity with edit_file, B3)
+
+`multi_edit` now accepts the same `expected_hash` parameter `edit_file` has had since Improvement B3 (the OCC stale-read token for detecting concurrent writes). Until this release, the protection only worked for single edits — a consumer editing a file in a concurrent scenario (file open in another editor, another agent calling `edit_file`) could opt into stale-read protection for a single edit but not for a batch, even though a single hash check before the atomic loop would cover the whole batch. See [issue #24](https://github.com/scopweb/mcp-filesystem-go-ultra/issues/24).
+
+**Fix**: `multi_edit` declares the `expected_hash` string parameter; the handler reads it and passes it to the engine. The engine computes FNV-1a of the file at call time and, on mismatch, returns the **exact same** `stale edit: file content changed since read (expected hash: X, actual: Y). Re-read the file with read_file to get the current content_hash, then retry.` error string that `edit_file` uses — so a consumer that pattern-matches on `stale edit:` retries the same way for both tools. The check happens **before** the edit loop and the backup creation, so a stale hash never creates an unnecessary backup and never applies any edits. Empty `expected_hash` disables the check (backward compatible with all existing callers).
+
+**Why byte-for-byte parity with `edit_file`'s error matters**: the user-facing error string is the consumer's only signal that a re-read is required. If the two tools diverged, every consumer would need two retry code paths for what is conceptually one condition.
+
+**Files changed:**
+
+| File | Change |
+|------|--------|
+| `core/edit_operations.go` | `MultiEdit` signature gains `expectedHash string`; new check after the file read rejects on hash mismatch with the same string `edit_file` uses |
+| `tools_batch.go` | `multi_edit` tool registration declares the parameter; handler reads it from args and threads it to the engine |
+| `core/pipeline.go` | Pipeline executor passes `""` (no OCC) — pipeline-level OCC is a separate concern |
+| 9 test files (`tests/bug{16,17,22,23,27}_test.go`, `multi_edit_occurrences_counter_test.go`, `undo_step_through_test.go`, `core/truncation_test.go`) | All existing `engine.MultiEdit(...)` call sites pass `""` for the new parameter — backward compatible |
+| `tests/multi_edit_expected_hash_test.go` | NEW — 4 regression tests: valid hash, stale hash, omitted hash, atomic rollback |
+| `CHANGELOG.md` | this entry |
+
+**Verification:**
+
+```bash
+go test ./tests/ -run "TestIssue24_" -v            # 4/4 pass
+go test ./...                                       # full suite green (no regressions in the 25+ other MultiEdit tests)
+```
+
 ## [Unreleased / 4.5.12] - 2026-06-11
 
 ### Dashboard — Trash tab (UI for soft-deleted files)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,29 @@ go test ./core/...                                  # full suite green
 go test ./tests/...                                 # full suite green
 ```
 
+### read_file content_hash — moved to structured response field (B1 fix)
+
+`read_file` (full-file mode) used to append a trailing line `# content_hash: <8hex>` to the response body. The line is the OCC token for stale-edit protection (echoed back as `edit_file` / `multi_edit` `expected_hash` to detect concurrent writes). The bug was that the line was **visually indistinguishable from legitimate Markdown content** — same `# comment` syntax, no separator, no label. A consumer (human or AI) copying the response text as an `old_text` anchor in `edit_file` got `no matches found`; in `multi_edit` the whole atomic batch rolled back. Root-caused via a controlled experiment on 2026-06-13 (probe file with a planted `00000000` line that never appeared in the response). See [issue #23](https://github.com/scopweb/mcp-filesystem-go-ultra/issues/23).
+
+**Fix — move the hash to a structured response field.** `read_file` now returns the file body as plain text (no trailer) and the hash as `result.StructuredContent["content_hash"]`. This uses the MCP standard `structuredContent` field (MCP-Go SDK's `NewToolResultStructured`); clients that understand it read the hash from there, clients that don't see only the file body. The OCC mechanism (`edit_file(expected_hash:…)`, `multi_edit(expected_hash:…)`) is unchanged. Range reads and batch `paths` reads were already trailer-free; this fix only changes the full-file path.
+
+**Migration note for clients**: any consumer that regex-extracted the trailing `# content_hash: <hex>` line from the read_file response text must read from `StructuredContent["content_hash"]` instead. The `expected_hash` parameter on `edit_file` and `multi_edit` still accepts the same 8-hex-char value, so the only change is *where you get the value from*, not the value itself.
+
+**Files changed:**
+
+| File | Change |
+|------|--------|
+| `tools_core.go` | `read_file` full-read path returns `NewToolResultStructured({"content_hash": …}, body)` — body no longer has the `# content_hash:` trailer; hash moves to the structured field |
+| `content_hash_test.go` | `TestContentHash_AppearsInRead` and `TestContentHash_Stable` updated to read from `StructuredContent`; new `TestContentHash_RoundTripsWithExpectedHash` exercises the OCC end-to-end (read → extract hash → use as `expected_hash` → edit succeeds) |
+| `CHANGELOG.md` | this entry |
+
+**Verification:**
+
+```bash
+go test -run "TestContentHash_|TestExpectedHash_" -v   # all 5 pass
+go test ./...                                            # full suite green
+```
+
 ## [Unreleased / 4.5.12] - 2026-06-11
 
 ### Dashboard — Trash tab (UI for soft-deleted files)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 # CHANGELOG - MCP Filesystem Server Ultra-Fast
 
+## [Unreleased / 4.5.13] - 2026-06-12
+
+### Hooks — examples + docs brought up to date
+
+The hooks system (`core/hooks.go`) has had **16 events** since the addition of `pre-read`/`post-read`/`pre-search`/`post-search` (added after the docs were last updated), but the user-facing examples and docs were stuck at 12. Also, `examples/hooks.example.json` had **malformed JSON** (duplicate content pasted at the end after the root `}`) — copying that file as `hooks.json` and starting the server with `--hooks-enabled --hooks-config=hooks.json` would fail to parse.
+
+**Fixes:**
+- **`examples/hooks.example.json`** — rewrote clean. Was JSON-invalid (duplicate content after root `}`); now a well-formed single object with all 16 events. The `post-delete` example now mentions the v4.5.11+ `sd_id` and `dest_path` metadata fields (so audit hooks can log the recoverable copy).
+- **`examples/hooks-test.json`** — already valid; now covered by a regression test so it can't silently break again.
+- **`examples/README.md`** — now mentions `hooks-test.json` (the working all-enabled testing config) and explains when to use it vs `hooks.example.json`; adds a snippet showing the soft-delete `post-delete` audit hook with `jq`.
+- **`docs-website/src/content/docs/features/hooks.md`** — corrected "12 Hook Events" → "16 Hook Events", added the missing `pre-read`/`post-read`/`pre-search`/`post-search` sections, added a "Soft-delete Metadata (v4.5.11+)" subsection that documents the `sd_id` + `dest_path` fields in the `post-delete` hook context.
+- **`core/hooks.go`** — removed unused `event HookEvent` parameter from `aggregateResults` (private method, single caller). No behavior change.
+- **`tests/hooks_examples_test.go`** — NEW. 3 regression tests:
+  - `TestHooksExampleJSONIsValid` — parses the file and asserts all 16 events are present
+  - `TestHooksTestJSONIsValid` — same for the testing config
+  - `TestHooksExampleHasNoDuplicateStructure` — round-trips the JSON to detect trailing junk (the original bug)
+
+**Why this matters:** `hooks.example.json` is the primary copy-paste template for users setting up the hooks system. A broken reference file would silently break any new user setup. The regression tests guarantee the example stays valid as the codebase evolves.
+
+**Files changed:**
+
+| File | Change |
+|---|---|
+| `examples/hooks.example.json` | rewritten clean + SD-ID example |
+| `examples/README.md` | mentions `hooks-test.json` + soft-delete snippet |
+| `docs-website/src/content/docs/features/hooks.md` | 12→16 events, new read/search sections, new soft-delete metadata subsection |
+| `core/hooks.go` | remove unused `event` param in `aggregateResults` |
+| `tests/hooks_examples_test.go` | NEW — 3 regression tests |
+| `CHANGELOG.md` | this entry |
+
+**Verification:**
+
+```bash
+go build ./...                                       # clean
+go test -run TestHooks ./tests/...                    # 0.045s, 3 cases green
+go test ./...                                        # full suite green
+```
+
 ## [Unreleased / 4.5.12] - 2026-06-11
 
 ### Dashboard — Trash tab (UI for soft-deleted files)

--- a/TOOL-REFERENCE.md
+++ b/TOOL-REFERENCE.md
@@ -1,4 +1,6 @@
-# filesystem-ultra Tool Reference (v4.4.0 — 31 tools)
+# filesystem-ultra Tool Reference (v4.5.12 — 20 tools)
+
+17 core + `git` (v4.5.2+) + `minify_js` (v4.5.7+) + `help` (discovery).
 
 ### Reading Files
 
@@ -42,13 +44,15 @@
 |------|------|------------|
 | List directory | `list_directory` | `path` |
 | File info | `get_file_info` | `path` |
-| File info (batch) | `get_file_info` | `paths` (JSON array: `'["a.go","dir/"]'`) |
+| File info (batch) | `get_file_info` | `paths` (JSON array: `'["file1.txt","dir/"]'`) |
 | Copy | `copy_file` | `source_path`, `dest_path` |
 | Move/rename | `move_file` | `source_path`, `dest_path` |
 | Delete (soft) | `delete_file` | `path` |
 | Delete multiple | `delete_file` | `paths` (JSON array: `'["a.txt","b.txt"]'`) |
 | Delete (permanent) | `delete_file` | `path`, `permanent: true` |
 | Create directory | `create_directory` | `path` |
+
+> **Soft-delete response (v4.5.11+)** — every `delete_file` (soft mode, the default) returns a **Soft-Delete ID** in the response. The file is moved to `<--backup-dir>/filesdelete/<sd-id>/<basename>` with a `metadata.json` sidecar. Use `backup(action:"restore_trash", sd_id:"...")` to restore. **If `--backup-dir` is not configured**, soft-delete uses a legacy walk-up layout and the response will say `(legacy)` — the file is recoverable only by manual `move_file`. See section 12 below for full recovery flow.
 
 ### Batch & Pipeline
 
@@ -57,20 +61,42 @@
 | Multi-file atomic ops | `batch_operations` | `request_json` — see below |
 | Multi-step pipeline | `batch_operations` | `pipeline_json` — see below |
 | Batch rename | `batch_operations` | `rename_json` |
+| Project-wide find/replace | `project_replace` | `path`, `find`, `replace`, `preview` (bool), `parallel` (bool) |
 
 ### Other
 
 | Need | Tool | Parameters |
 |------|------|------------|
-| Backup management | `backup` | `action` (list/info/compare/cleanup/restore/undo_last), `backup_id` |
-| Restore backup | `backup` | `action: "restore"`, `backup_id`, `file_path` (optional) |
+| Backup management (pre-edit) | `backup` | `action` (list/info/compare/cleanup/restore/undo_last/undo_chain), `backup_id` |
+| Restore pre-edit backup | `backup` | `action: "restore"`, `backup_id`, `file_path` (optional) |
 | Undo last edit | `backup` | `action: "undo_last"`, `preview: true` (optional) |
+| List soft-deleted files | `backup` | `action: "list_trash"`, `filter_path` (optional), `older_than_days` (optional), `limit` (default 50) |
+| Restore soft-deleted file | `backup` | `action: "restore_trash"`, `sd_id` (required) |
+| Permanently delete old trash | `backup` | `action: "purge_trash"`, `older_than_days` (default 7), `dry_run` (default true) |
 | Analyze before doing | `analyze_operation` | `path`, `operation` (file/edit/delete/write/optimize) |
 | Performance stats | `server_info` | `action: "stats"` |
 | Help | `server_info` | `action: "help"`, `topic` (optional) |
 | Artifact capture | `server_info` | `action: "artifact"`, `sub_action` (capture/write/info) |
 | WSL sync | `wsl` | `wsl_path` or `windows_path`, `direction` |
 | WSL status | `wsl` | `action: "status"` |
+
+### Version Control (v4.5.2+)
+
+| Need | Tool | Parameters |
+|------|------|------------|
+| Git operations | `git` | `action` (init/status/diff/log/add/commit/restore/branch), `path`, `message` (or `auto_message: true` for conventional commits) |
+
+### JavaScript (v4.5.7+)
+
+| Need | Tool | Parameters |
+|------|------|------------|
+| Minify JavaScript (pure Go, no Node) | `minify_js` | `path`, `content` (optional, in-memory) |
+
+### Discovery
+
+| Need | Tool | Parameters |
+|------|------|------------|
+| List all tools + capabilities | `help` | (no params) |
 
 ---
 
@@ -80,6 +106,7 @@
 - Copy-paste paths exactly from `list_directory` or `search_files` results
 - **Never retype paths from memory** — typos cause silent failures
 - If a tool returns "file not found", double-check the path character by character
+- **Caso documentado (2026-06-11):** un path con capitalización mal (ej. `estats.razor` en vez de `Estats.razor`) se resuelve correctamente en Windows (case-insensitive) pero el archivo editado downstream registra la clase con la capitalización del path pasado → errores de compilación que aparecen 3 capas más abajo (compilador Razor: `RZ10011 class estats`). **El path SIEMPRE debe copiarse de `list_directory` o `read_file`, nunca escribirse de memoria, especialmente cuando hay capitalización, acentos, o guiones vs underscores en juego.**
 
 ### 2. Read before editing
 - **ALWAYS** read the file (or relevant range) before calling `edit_file` or `multi_edit`
@@ -140,15 +167,82 @@ For replacing large code blocks (>10 lines):
 - If a tool returns no response (timeout): retry once, the file system may have been briefly locked
 
 ### 10. Disaster Recovery — UNDO and backup restore
-- Every `edit_file` and `multi_edit` response includes: `UNDO: backup(action:"restore", backup_id:"...")`
-- Quick undo (no backup_id needed): `backup(action:"undo_last")`
-- Preview before undo: `backup(action:"undo_last", preview:true)`
-- Find backups for a specific file: `backup(action:"list", filter_path:"filename")`
-- If edits make things WORSE, **STOP editing and RESTORE** from backup — repeated edits on a broken file make recovery harder
-- For HIGH risk edits, verify the result: `read_file(path, mode:"tail")` to confirm file is complete
-- Full recovery guide: `server_info(action:"help", topic:"recovery")`
 
-### 11. Use filesystem tools — never bash alternatives
+**Backup format in responses:**
+- Compact: `M file.go | 7@+7-0 | 42L | UNDO:20260501-123650 | chain:20260501-123649`
+  - `UNDO:20260501-123650` — truncated ID (12 chars), use for display or `backup(action:"restore", backup_id:"...")`
+  - `chain:20260501-123649` — parent backup ID, indicates previous version available for step-through undo
+- Verbose: `✓ UNDO:20260501-123650-333c964cc3af7a82 ← chain:20260501-123649-...`
+
+**Undo operations:**
+- Quick undo (no backup_id needed): `backup(action:"undo_last")`
+- **Step-through undo** (recomendado): `backup(action:"undo_last", file_path:"...")` — recorre la cadena de backups hacia atrás, uno a uno
+- Preview next step: `backup(action:"undo_last", file_path:"...", preview:true)`
+- Ver cadena completa: `backup(action:"undo_chain", file_path:"...")`
+- Restore specific backup: `backup(action:"restore", backup_id:"20260501-123650-333c964cc3af7a82")` (full ID required)
+- Find backups for a specific file: `backup(action:"list", filter_path:"filename")`
+
+**Auto-verify integrity**: operaciones HIGH/CRITICAL incluyen verificación automática post-edit (legibilidad, tamaño, hash). Si el archivo quedó corrupto o truncado, se reporta inmediatamente.
+
+For HIGH risk edits, verify the result: `read_file(path, mode:"tail")` to confirm file is complete.
+
+Full recovery guide: `server_info(action:"help", topic:"recovery")`
+
+### 11. Soft-delete recovery (v4.5.11+) — SD-ID and `restore_trash`
+
+**Every soft-delete returns a Soft-Delete ID (SD-ID)** in the response — a string like `sd-20260611-150455-a1b2c3d4`. The file is moved to `<--backup-dir>/filesdelete/<sd-id>/<basename>` with a `metadata.json` sidecar. The SD-ID is the only handle the AI has to restore the file.
+
+**Response shapes (v4.5.11+):**
+```
+Compact:
+D foo.razor | SD:sd-20260611-150455-a1b2c3d4 | restore: backup(action:"restore_trash", sd_id:"sd-20260611-150455-a1b2c3d4")
+
+Verbose:
+OK: C:\path\to\foo.razor soft-deleted
+   SD-ID: sd-20260611-150455-a1b2c3d4
+   Trash: C:\backup-dir\filesdelete\sd-20260611-150455-a1b2c3d4\foo.razor
+   Restore: backup(action:"restore_trash", sd_id:"sd-20260611-150455-a1b2c3d4")
+   Or manually: move_file(<trash_path> → <original_path>)
+```
+
+**Restore flow (when `--backup-dir` is configured — recommended):**
+1. Capture the SD-ID from the soft-delete response
+2. If unsure the file is recoverable, list: `backup(action:"list_trash", filter_path:"foo.razor")`
+3. Restore: `backup(action:"restore_trash", sd_id:"<sd-id>")`
+4. The file moves back to its original location. Refuses to overwrite an existing file (returns 409 Conflict).
+
+**Bulk cleanup:**
+- `backup(action:"list_trash", older_than_days:7)` — preview what would be purged
+- `backup(action:"purge_trash", older_than_days:7, dry_run:false)` — permanently delete entries older than 7 days
+- Dashboard Trash tab provides a UI for the same actions.
+
+**When `--backup-dir` is NOT configured** (legacy mode): the file goes to a parallel `filesdelete/` folder near the project root. The response will say `(legacy)` and **no SD-ID is returned** — recovery is only via manual `move_file`. Always pass `--backup-dir` to enable `restore_trash`.
+
+**Prefer `write_file` for whole-file rewrites** — see Rule 12.
+
+### 12. ⚠️ Nunca `edit_file` para rewrite completo (bug del 2026-06-11)
+
+**Síntoma observado:** `edit_file(path, old_text=<15 líneas header>, new_text=<archivo completo ~150 líneas>)` produjo un archivo de **298 líneas con el SP/procedimiento duplicado**. El header se reemplazó correctamente, pero el resto del archivo viejo quedó concatenado debajo del `new_text`.
+
+**Causa:** `edit_file` en modo default (`replace`) hace match EXACTO de `old_text` y sustituye **solo ese fragmento**. El resto del archivo permanece intacto. El "rewrite" que el modelo tenía en cabeza nunca ocurrió — solo se intercambió un bloque pequeño.
+
+**Regla:** Cuando hay que reescribir un archivo entero o la mayoría de su contenido → usar **`write_file`** directamente, nunca `edit_file`.
+
+**Heurística de decisión:**
+
+| Situación | Herramienta correcta |
+|-----------|---------------------|
+| `len(new_text) > 2 * len(old_text)` y archivo tiene contenido más allá del match | **`write_file`** |
+| Cambio pequeño y puntual (`len(new_text) ≈ len(old_text)`, mismo rango) | `edit_file` mode `replace` |
+| Reemplazo global de un patrón (todas las ocurrencias) | `edit_file` mode `search_replace` |
+| Renombrar tokens en árbol completo | `project_replace` o `batch_operations` con `search_and_replace` |
+| Múltiples cambios pequeños en el mismo archivo | `multi_edit` con varios anchors |
+
+**Truco anti-bug:** Antes de llamar `edit_file`, calcular mentalmente el ratio `len(new_text) / len(old_text)`. Si es > 2 y la operación no es un rename global, replantear con `write_file` o fragmentar en `multi_edit`.
+
+**Detección server-side (✅ activa desde v4.5.10, 2026-06-11):** `edit_file` ahora BLOQUEA automáticamente este patrón. La guarda `core.CheckEditRewrite` dispara cuando se cumplen 3 señales: (1) `new_text > 2× old_text`, (2) el archivo tiene >50% de contenido fuera del match, (3) `new_text > 500 bytes` Y `>50%` del archivo. El bloque devuelve un error claro sugiriendo `write_file`. Override: pasar `force:true` — crea un backup de seguridad y aplica. El audit log registra `feedback_pattern: "accidental_rewrite"` cuando dispara.
+
+### 13. Use filesystem tools — never bash alternatives
 - **Search files** → `search_files` (never `grep`, `find`, `rg`)
 - **Read files** → `read_file` (never `cat`, `type`, `bat`)
 - **List directories** → `list_directory` (never `ls`, `dir`)

--- a/content_hash_test.go
+++ b/content_hash_test.go
@@ -16,8 +16,11 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 )
 
-// TestContentHash_AppearsInRead verifies that read_file appends a
-// "# content_hash: XXXXXXXX" line at the end of its response.
+// TestContentHash_AppearsInRead verifies that read_file returns the
+// content_hash as a structured response field (Bug B1 fix: it is no longer
+// appended as a `# content_hash: XXXXXXXX` line to the file body, which
+// was visually indistinguishable from legitimate Markdown content and
+// caused consumers to anchor edits on it).
 func TestContentHash_AppearsInRead(t *testing.T) {
 	dir := t.TempDir()
 	reg := buildEditRegistry(t, dir, false)
@@ -39,22 +42,38 @@ func TestContentHash_AppearsInRead(t *testing.T) {
 	if result.IsError {
 		t.Fatalf("read_file returned error: %v", result.Content)
 	}
-	text := resultText(t, result)
 
-	// Extract the content_hash line
-	re := regexp.MustCompile(`(?m)^# content_hash: ([0-9a-f]{8})$`)
-	m := re.FindStringSubmatch(text)
-	if m == nil {
-		t.Fatalf("expected '# content_hash: XXXXXXXX' line in response, got:\n%s", text)
+	// Bug B1 regression: the file body returned to the client must NOT
+	// contain a `# content_hash:` line. The hash lives in StructuredContent.
+	text := resultText(t, result)
+	if strings.Contains(text, "# content_hash:") {
+		t.Errorf("file body still contains '# content_hash:' trailer (B1 regression). The trailer must live in StructuredContent, not in the body text. Body:\n%s", text)
 	}
-	reportedHash := m[1]
-	// Compute what the hash should be (FNV-1a of "hello world\n" + the appended line is circular,
-	// so we just verify it's 8 hex chars — already done by regex).
-	_ = reportedHash
+
+	// The hash should be in StructuredContent under the "content_hash" key.
+	if result.StructuredContent == nil {
+		t.Fatal("read_file did not set StructuredContent (B1 fix expects the hash in a structured field)")
+	}
+	m, ok := result.StructuredContent.(map[string]any)
+	if !ok {
+		t.Fatalf("StructuredContent is %T, expected map[string]any", result.StructuredContent)
+	}
+	hashRaw, present := m["content_hash"]
+	if !present {
+		t.Fatalf("StructuredContent is missing 'content_hash' key. Got: %#v", m)
+	}
+	hash, ok := hashRaw.(string)
+	if !ok {
+		t.Fatalf("content_hash is %T, expected string", hashRaw)
+	}
+	re := regexp.MustCompile(`^[0-9a-f]{8}$`)
+	if !re.MatchString(hash) {
+		t.Errorf("content_hash %q is not 8 lowercase hex chars", hash)
+	}
 }
 
 // TestContentHash_Stable verifies that two reads of the same unchanged file
-// return the same content_hash.
+// return the same content_hash (now read from StructuredContent).
 func TestContentHash_Stable(t *testing.T) {
 	dir := t.TempDir()
 	reg := buildEditRegistry(t, dir, false)
@@ -68,19 +87,73 @@ func TestContentHash_Stable(t *testing.T) {
 			Params: mcp.CallToolParams{Name: "read_file", Arguments: map[string]interface{}{"path": path}},
 		}
 		result, _ := reg.readFileHandler(context.Background(), req)
-		return resultText(t, result)
+		m, ok := result.StructuredContent.(map[string]any)
+		if !ok {
+			t.Fatalf("StructuredContent is %T, expected map[string]any", result.StructuredContent)
+		}
+		hash, _ := m["content_hash"].(string)
+		return hash
 	}
-	text1 := read()
-	text2 := read()
+	hash1 := read()
+	hash2 := read()
 
-	re := regexp.MustCompile(`# content_hash: ([0-9a-f]{8})`)
-	m1 := re.FindStringSubmatch(text1)
-	m2 := re.FindStringSubmatch(text2)
-	if m1 == nil || m2 == nil {
-		t.Fatal("content_hash line missing in one of the reads")
+	if hash1 == "" || hash2 == "" {
+		t.Fatal("content_hash missing from StructuredContent in one of the reads")
 	}
-	if m1[1] != m2[1] {
-		t.Errorf("content_hash should be stable for unchanged file: %q vs %q", m1[1], m2[1])
+	if hash1 != hash2 {
+		t.Errorf("content_hash should be stable for unchanged file: %q vs %q", hash1, hash2)
+	}
+}
+
+// TestContentHash_RoundTripsWithExpectedHash verifies the OCC mechanism
+// still works end-to-end after the B1 fix: read_file returns a hash in
+// StructuredContent, the consumer extracts it, and edit_file accepts it
+// as `expected_hash` to confirm the file has not been concurrently
+// modified. This is the documented usage pattern; the regression test
+// guards against any future change that breaks the round-trip.
+func TestContentHash_RoundTripsWithExpectedHash(t *testing.T) {
+	dir := t.TempDir()
+	reg := buildEditRegistry(t, dir, false)
+	path := filepath.Join(dir, "round_trip.txt")
+	if err := os.WriteFile(path, []byte("alpha\nbeta\n"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// 1. read_file
+	readReq := mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name:      "read_file",
+			Arguments: map[string]interface{}{"path": path},
+		},
+	}
+	readResult, err := reg.readFileHandler(context.Background(), readReq)
+	if err != nil {
+		t.Fatalf("read_file: %v", err)
+	}
+	m, ok := readResult.StructuredContent.(map[string]any)
+	if !ok {
+		t.Fatalf("read_file StructuredContent is %T, expected map[string]any", readResult.StructuredContent)
+	}
+	hash, _ := m["content_hash"].(string)
+	if hash == "" {
+		t.Fatal("content_hash missing from StructuredContent")
+	}
+
+	// 2. edit_file with the extracted hash → must be accepted
+	editResult := callEdit(t, reg, map[string]interface{}{
+		"path":          path,
+		"old_text":      "alpha",
+		"new_text":      "ALPHA",
+		"expected_hash": hash,
+	})
+	if editResult.IsError {
+		t.Fatalf("edit_file with valid expected_hash should succeed, got error: %s", resultText(t, editResult))
+	}
+
+	// 3. Verify the file was modified
+	after, _ := os.ReadFile(path)
+	if !strings.Contains(string(after), "ALPHA") {
+		t.Errorf("edit was rejected or did not apply: %s", after)
 	}
 }
 

--- a/core/edit_operations.go
+++ b/core/edit_operations.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"hash/fnv"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -1150,7 +1151,7 @@ type MultiEditResult struct {
 // 4. Only one backup is created
 // ULTRA-FAST: Designed for Claude Desktop batch editing
 // Bug #17: Added risk assessment, context validation, hooks, per-edit detail, and "already_present" detection
-func (e *UltraFastEngine) MultiEdit(ctx context.Context, path string, edits []MultiEditOperation, force bool, dryRun bool, tolerantWhitespace bool) (*MultiEditResult, error) {
+func (e *UltraFastEngine) MultiEdit(ctx context.Context, path string, edits []MultiEditOperation, force bool, dryRun bool, tolerantWhitespace bool, expectedHash string) (*MultiEditResult, error) {
 	// Normalize path (handles WSL ↔ Windows conversion)
 	path = NormalizePath(path)
 
@@ -1170,6 +1171,23 @@ func (e *UltraFastEngine) MultiEdit(ctx context.Context, path string, edits []Mu
 		return nil, fmt.Errorf("error reading file: %w", err)
 	}
 	originalContent := string(content)
+
+	// Bug #24: OCC stale-edit protection for batch edits (parity with EditFile).
+	// When expectedHash is non-empty, the consumer is asserting that the file's
+	// current FNV-1a must match the hash they captured from a prior read_file.
+	// If the file changed since (concurrent write, external editor, another
+	// agent), reject the entire batch with the same error string edit_file
+	// uses, so a consumer that retries on "stale edit:" works the same way
+	// for both tools. Empty expectedHash disables the check (backward
+	// compatible with all existing callers that don't pass it).
+	if expectedHash != "" {
+		h := fnv.New32a()
+		h.Write(content)
+		actualHash := fmt.Sprintf("%08x", h.Sum32())
+		if actualHash != expectedHash {
+			return nil, fmt.Errorf("stale edit: file content changed since read (expected hash: %s, actual: %s). Re-read the file with read_file to get the current content_hash, then retry.", expectedHash, actualHash)
+		}
+	}
 
 	// Detect original EOL style to preserve it on write (Bug #33: EOL preservation)
 	originalEOL := detectEOL(originalContent)

--- a/core/edit_operations.go
+++ b/core/edit_operations.go
@@ -1284,6 +1284,12 @@ func (e *UltraFastEngine) MultiEdit(ctx context.Context, path string, edits []Mu
 	totalLinesRemoved := 0
 	firstStartLine := 0
 	lastEndLine := 0
+	// Bug #21: aggregateImpact built by calculateMultiEditImpact is an estimate
+	// from a simulated content run and does not assign Occurrences — that field
+	// would stay at 0 and FormatRiskNotice would print "0 replacements" even
+	// when every edit applied. Track the real per-edit ReplacementCount here
+	// and assign it to aggregateImpact.Occurrences after the loop.
+	var totalReplacements int64
 
 	for i, edit := range edits {
 		detail := EditDetail{
@@ -1365,6 +1371,7 @@ func (e *UltraFastEngine) MultiEdit(ctx context.Context, path string, edits []Mu
 		detail.MatchConfidence = editResult.MatchConfidence
 		currentContent = editResult.ModifiedContent
 		result.SuccessfulEdits++
+		totalReplacements += int64(editResult.ReplacementCount)
 		totalLinesAffected += editResult.LinesAffected
 		// Track line range for clickable link annotation
 		if editResult.StartLine > 0 {
@@ -1393,6 +1400,12 @@ func (e *UltraFastEngine) MultiEdit(ctx context.Context, path string, edits []Mu
 	result.TotalLines = strings.Count(currentContent, "\n") + 1
 	result.StartLine = firstStartLine
 	result.EndLine = lastEndLine
+
+	// Bug #21: feed the real per-edit replacement count into aggregateImpact
+	// so the risk notice doesn't read "0 replacements" when edits did apply.
+	// Three FormatRiskNotice call sites downstream (skipped-only, dry_run,
+	// main path) all read aggregateImpact.Occurrences.
+	aggregateImpact.Occurrences = int(totalReplacements)
 
 	// If no edits succeeded and none were already_present, return error
 	if result.SuccessfulEdits == 0 && result.SkippedEdits == 0 {

--- a/core/hooks.go
+++ b/core/hooks.go
@@ -219,7 +219,7 @@ func (hm *HookManager) ExecuteHooks(ctx context.Context, event HookEvent, hookCt
 	results := hm.executeHooksParallel(ctx, matchedHooks, hookCtx)
 
 	// Aggregate results
-	return hm.aggregateResults(results, event)
+	return hm.aggregateResults(results)
 }
 
 // matchesPattern checks if a tool name matches a pattern.
@@ -469,7 +469,7 @@ func (hm *HookManager) parseHookOutput(stdout, stderr string, exitCode int) *Hoo
 }
 
 // aggregateResults combines multiple hook results into a final decision
-func (hm *HookManager) aggregateResults(results []*HookResult, event HookEvent) (*HookResult, error) {
+func (hm *HookManager) aggregateResults(results []*HookResult) (*HookResult, error) {
 	if len(results) == 0 {
 		return &HookResult{Decision: HookAllow}, nil
 	}

--- a/core/impact_analyzer.go
+++ b/core/impact_analyzer.go
@@ -360,8 +360,20 @@ func (ci *ChangeImpact) FormatRiskNotice(backupID string, filePath ...string) st
 		magnitude = "large edit"
 	}
 
+	// Bug #21: cap the displayed percentage at 100%. The honest-scope formula
+	// (Σ max(|oldText|,|newText|) / fileSize × 100) is an upper bound on bytes
+	// touched and can exceed 100% when edits are net-insertions. The magnitude
+	// word ("large edit" / "very large edit") already encodes severity above
+	// the 40%/80% thresholds, so printing "137% of file" is misleading — it
+	// reads as "the file grew beyond its size" when it didn't. The
+	// change_percentage JSON field is left untouched; only the *displayed*
+	// value in the notice string is clamped.
+	displayPct := ci.ChangePercentage
+	if displayPct > 100 {
+		displayPct = 100
+	}
 	notice.WriteString(fmt.Sprintf("\nnote: %s (~%d bytes affected, %d replacements, %.0f%% of file)",
-		magnitude, ci.CharactersChanged, ci.Occurrences, ci.ChangePercentage))
+		magnitude, ci.CharactersChanged, ci.Occurrences, displayPct))
 
 	if backupID != "" {
 		notice.WriteString(fmt.Sprintf(". backup:%s", backupID))

--- a/core/pipeline.go
+++ b/core/pipeline.go
@@ -625,7 +625,7 @@ func (pe *PipelineExecutor) executeMultiEdit(ctx context.Context, step PipelineS
 			totalEdits += count
 		} else {
 			// Perform actual multi-edit
-			editResult, err := pe.engine.MultiEdit(ctx, normalizedPath, edits, force, dryRun, false)
+			editResult, err := pe.engine.MultiEdit(ctx, normalizedPath, edits, force, dryRun, false, "")
 			if err != nil {
 				return &PipelineStepError{
 					StepID:  step.ID,

--- a/core/truncation_test.go
+++ b/core/truncation_test.go
@@ -50,7 +50,7 @@ func TestBugTruncation_LargeFileMultiEditWithFailure(t *testing.T) {
 		{OldText: "M5_UNIQUE_ID_5005", NewText: "FifthMethodRenamed"},
 	}
 
-	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false, false)
+	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false, false, "")
 
 	t.Logf("MultiEdit returned: err=%v", err)
 	if result != nil {
@@ -123,7 +123,7 @@ func TestBugTruncation_MultiEditAllSucceed(t *testing.T) {
 		{OldText: `fmt.Println("Line 100")`, NewText: `fmt.Println("HUNDREDTH")`},
 	}
 
-	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false, false)
+	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false, false, "")
 	if err != nil {
 		t.Fatalf("MultiEdit should succeed when all edits work: %v", err)
 	}
@@ -176,7 +176,7 @@ func TestBugTruncation_HighRiskMultiEdit(t *testing.T) {
 		{OldText: "NONEXISTENT_TOKEN_XYZ", NewText: "X"},
 	}
 
-	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false, false)
+	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false, false, "")
 
 	// Should fail due to atomic rollback (edit #3 fails)
 	if err == nil {

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,7 +4,8 @@ Esta carpeta contiene archivos de ejemplo para configuración y uso del MCP.
 
 ## Archivos
 
-- **hooks.example.json** - Ejemplo de configuración de hooks (auto-format, validación)
+- **hooks.example.json** - Ejemplo completo de configuración de hooks (16 eventos, todos deshabilitados por defecto — actívalos selectivamente con `enabled: true`)
+- **hooks-test.json** - Configuración de hooks con todos los eventos habilitados y `cmd /c echo` (Windows-friendly), útil para verificar que el sistema dispara los hooks correctamente. Incluye hooks de bloqueo (`failOnError: true`) para `.env` y `.key` que puedes activar para probar el rechazo.
 - **request.json** - Ejemplos de requests MCP
 - **test_request.json** - Requests de prueba
 
@@ -22,6 +23,35 @@ Luego inicia el servidor con:
 ```bash
 mcp-filesystem-ultra.exe --hooks-enabled --hooks-config=hooks.json
 ```
+
+**Para verificar que el sistema de hooks funciona** (dispara todos los 16 eventos con logs visibles), copia `hooks-test.json` en su lugar:
+
+```bash
+cp examples/hooks-test.json hooks.json
+mcp-filesystem-ultra.exe --hooks-enabled --hooks-config=hooks.json
+```
+
+Después de cualquier operación de archivo, verás los mensajes `[PRE-WRITE]`, `[POST-EDIT]`, etc. en los logs del servidor.
+
+### Hook post-delete con SD-ID (v4.5.11+)
+
+Desde v4.5.11, el `post-delete` recibe `sd_id` y `dest_path` en el `metadata` del hook context cuando `--backup-dir` está configurado. Esto te permite auditar/registrar el ID de la papelera por archivo:
+
+```json
+"post-delete": [
+  {
+    "pattern": "*",
+    "hooks": [{
+      "type": "command",
+      "command": "jq -r '\"sd_id=\\(.metadata.sd_id) dest=\\(.metadata.dest_path)\"' >> audit.log",
+      "failOnError": false,
+      "enabled": true
+    }]
+  }
+]
+```
+
+El hook context completo está documentado en `docs-website/src/content/docs/features/hooks.md`.
 
 ### Testing Requests
 Los archivos JSON de ejemplo te muestran el formato correcto para hacer requests al servidor MCP.

--- a/examples/hooks.example.json
+++ b/examples/hooks.example.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "MCP Filesystem Ultra — Full hook configuration example (16 events). Copy to hooks.json and start server with --hooks-enabled --hooks-config=hooks.json",
+  "_comment": "MCP Filesystem Ultra — Full hook configuration example (16 events). Copy to hooks.json and start server with --hooks-enabled --hooks-config=hooks.json. Most hooks are disabled by default; set enabled:true on individual entries to activate them. See examples/hooks-test.json for a working setup with all hooks enabled and cmd /c echo (Windows-friendly).",
   "hooks": {
     "pre-write": [
       {
@@ -131,15 +131,15 @@
     ],
     "post-delete": [
       {
-        "_comment": "Cleanup companion files or update audit logs after deletion.",
+        "_comment": "v4.5.11+: when --backup-dir is configured, the hook context metadata includes `sd_id` (the soft-delete ID) and `dest_path` (where the file lives in the trash). Use these to log/audit the recoverable copy. For hard deletes (permanent:true) these fields are empty.",
         "pattern": "*",
         "hooks": [
           {
             "type": "command",
-            "command": "echo Post-delete audit",
+            "command": "echo Post-delete audit: sd_id=%SD_ID% dest=%DEST_PATH%",
             "timeout": 5,
             "failOnError": false,
-            "description": "Audit log: record deletion completion",
+            "description": "Audit log: record soft-delete (sd_id + trash path)",
             "enabled": false
           }
         ]
@@ -313,109 +313,6 @@
             "timeout": 5,
             "failOnError": false,
             "description": "Compliance: record search queries and match counts",
-            "enabled": false
-          }
-        ]
-      }
-    ]
-  }
-}
-
-      {
-        "pattern": "*.go",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "gofmt -w",
-            "timeout": 10,
-            "failOnError": false,
-            "description": "Format Go files before writing",
-            "enabled": true
-          }
-        ]
-      },
-      {
-        "pattern": "*.js",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "prettier --write",
-            "timeout": 10,
-            "failOnError": false,
-            "description": "Format JavaScript files with prettier",
-            "enabled": true
-          }
-        ]
-      },
-      {
-        "pattern": "*.py",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "black",
-            "timeout": 10,
-            "failOnError": false,
-            "description": "Format Python files with black",
-            "enabled": true
-          }
-        ]
-      }
-    ],
-    "post-write": [
-      {
-        "pattern": "*",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "echo File written successfully",
-            "timeout": 5,
-            "failOnError": false,
-            "description": "Log file write",
-            "enabled": false
-          }
-        ]
-      }
-    ],
-    "pre-edit": [
-      {
-        "pattern": "*.go",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "go vet",
-            "timeout": 30,
-            "failOnError": false,
-            "description": "Validate Go syntax before editing",
-            "enabled": false
-          }
-        ]
-      }
-    ],
-    "post-edit": [
-      {
-        "pattern": "*.go",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "go build",
-            "timeout": 60,
-            "failOnError": false,
-            "description": "Verify Go files compile after edit",
-            "enabled": false
-          }
-        ]
-      }
-    ],
-    "pre-delete": [
-      {
-        "pattern": "*",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "echo Deleting file",
-            "timeout": 5,
-            "failOnError": false,
-            "description": "Confirm deletion",
             "enabled": false
           }
         ]

--- a/tests/bug16_test.go
+++ b/tests/bug16_test.go
@@ -295,7 +295,7 @@ func TestBug16_MultiEditWithForce(t *testing.T) {
 		{OldText: "line3", NewText: "modified3"},
 	}
 
-	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false, false)
+	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false, false, "")
 	if err != nil {
 		t.Fatalf("MultiEdit should succeed, got error: %v", err)
 	}

--- a/tests/bug17_test.go
+++ b/tests/bug17_test.go
@@ -31,7 +31,7 @@ func TestBug17_OverlappingEditsNotMisreported(t *testing.T) {
 		},
 	}
 
-	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false, false)
+	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false, false, "")
 	if err != nil {
 		t.Fatalf("MultiEdit should succeed, got error: %v", err)
 	}
@@ -84,7 +84,7 @@ func TestBug17_AllEditsApplied(t *testing.T) {
 		{OldText: "line3_target", NewText: "modified3"},
 	}
 
-	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false, false)
+	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false, false, "")
 	if err != nil {
 		t.Fatalf("MultiEdit should succeed: %v", err)
 	}
@@ -122,7 +122,7 @@ func TestBug17_GenuineFailureStillReported(t *testing.T) {
 		{OldText: "NONEXISTENT_TEXT", NewText: "should_fail"},
 	}
 
-	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false, false)
+	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false, false, "")
 
 	// Bug #27: multi_edit is now atomic — should return error when any edit fails
 	if err == nil {
@@ -178,7 +178,7 @@ func TestBug17_RiskAssessmentCriticalProceeds(t *testing.T) {
 		{OldText: "AB", NewText: "CD"},
 	}
 
-	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false, false)
+	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false, false, "")
 	if err != nil {
 		t.Fatalf("CRITICAL risk MultiEdit should proceed (Bug #22), got error: %v", err)
 	}
@@ -207,7 +207,7 @@ func TestBug17_RiskAssessmentCriticalForceProceeds(t *testing.T) {
 		{OldText: "AB", NewText: "CD"},
 	}
 
-	result, err := engine.MultiEdit(context.Background(), testFile, edits, true, false, false)
+	result, err := engine.MultiEdit(context.Background(), testFile, edits, true, false, false, "")
 	if err != nil {
 		t.Fatalf("CRITICAL risk with force=true should succeed: %v", err)
 	}
@@ -238,7 +238,7 @@ func TestBug17_EditDetailsPopulated(t *testing.T) {
 		{OldText: "ccc", NewText: "zzz"},
 	}
 
-	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false, false)
+	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false, false, "")
 
 	// Bug #27: atomic rollback — any failed edit means file is NOT modified
 	if err == nil {
@@ -285,7 +285,7 @@ func TestBug17_BackwardCompatibility(t *testing.T) {
 		{OldText: "hello", NewText: "goodbye"},
 	}
 
-	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false, false)
+	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false, false, "")
 	if err != nil {
 		t.Fatalf("Should succeed: %v", err)
 	}
@@ -334,7 +334,7 @@ func TestBug17_AllAlreadyPresent(t *testing.T) {
 		{OldText: "original3", NewText: "modified3"},
 	}
 
-	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false, false)
+	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false, false, "")
 	if err != nil {
 		t.Fatalf("MultiEdit should succeed: %v", err)
 	}
@@ -368,7 +368,7 @@ func TestBug17_AmbiguousOldTextNotInOriginal(t *testing.T) {
 		{OldText: "original3", NewText: "modified3"},
 	}
 
-	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false, false)
+	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false, false, "")
 	if err == nil {
 		t.Fatal("MultiEdit should return error for ambiguous edits")
 	}
@@ -409,7 +409,7 @@ func TestBug17_MixedOverlapAndIndependent(t *testing.T) {
 		{OldText: "DDD", NewText: "ZZZ"},
 	}
 
-	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false, false)
+	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false, false, "")
 	if err != nil {
 		t.Fatalf("Should succeed: %v", err)
 	}

--- a/tests/bug22_multi_edit_test.go
+++ b/tests/bug22_multi_edit_test.go
@@ -63,7 +63,7 @@ func TestBug22_MultiEditOldStrAlias(t *testing.T) {
 		t.Fatal("NewText is empty — new_str alias not recognized")
 	}
 
-	result, err := engine.MultiEdit(ctx, filePath, edits, false, false, false)
+	result, err := engine.MultiEdit(ctx, filePath, edits, false, false, false, "")
 	if err != nil {
 		t.Fatalf("MultiEdit failed with old_str alias: %v", err)
 	}
@@ -106,7 +106,7 @@ func TestBug22_MultiEditMixedAliases(t *testing.T) {
 		t.Fatalf("Mixed alias parsing failed: edit[0].OldText=%q, edit[1].OldText=%q", edits[0].OldText, edits[1].OldText)
 	}
 
-	result, err := engine.MultiEdit(ctx, filePath, edits, false, false, false)
+	result, err := engine.MultiEdit(ctx, filePath, edits, false, false, false, "")
 	if err != nil {
 		t.Fatalf("MultiEdit with mixed aliases failed: %v", err)
 	}
@@ -140,7 +140,7 @@ func TestBug22_MultiEditLiteralEscapesContextValidation(t *testing.T) {
 		{OldText: "line1\\nline2", NewText: "lineA\\nlineB"},
 	}
 
-	result, err := engine.MultiEdit(ctx, filePath, edits, false, false, false)
+	result, err := engine.MultiEdit(ctx, filePath, edits, false, false, false, "")
 	if err != nil {
 		t.Fatalf("MultiEdit failed with literal escapes: %v", err)
 	}
@@ -177,7 +177,7 @@ func main() {
 		t.Fatalf("Failed to parse standard edits: %v", err)
 	}
 
-	result, err := engine.MultiEdit(ctx, filePath, edits, false, false, false)
+	result, err := engine.MultiEdit(ctx, filePath, edits, false, false, false, "")
 	if err != nil {
 		t.Fatalf("MultiEdit with standard old_text failed: %v", err)
 	}

--- a/tests/bug23_test.go
+++ b/tests/bug23_test.go
@@ -107,7 +107,7 @@ func TestBug23_MultiEdit_CRLFMatchesLF(t *testing.T) {
 		{OldText: "gamma\n", NewText: "GAMMA\n"},
 	}
 
-	result, err := engine.MultiEdit(context.Background(), filePath, edits, true, false, false)
+	result, err := engine.MultiEdit(context.Background(), filePath, edits, true, false, false, "")
 	if err != nil {
 		t.Fatalf("MultiEdit failed: %v", err)
 	}

--- a/tests/bug27_multi_edit_atomic_test.go
+++ b/tests/bug27_multi_edit_atomic_test.go
@@ -52,7 +52,7 @@ func main() {
 		},
 	}
 
-	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false, false)
+	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false, false, "")
 
 	// Should return an error (atomic rollback)
 	if err == nil {
@@ -122,7 +122,7 @@ func goodbye() {
 		},
 	}
 
-	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false, false)
+	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false, false, "")
 	if err != nil {
 		t.Fatalf("Expected success, got error: %v", err)
 	}
@@ -187,7 +187,7 @@ function gestionData() {
 		},
 	}
 
-	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false, false)
+	result, err := engine.MultiEdit(context.Background(), testFile, edits, false, false, false, "")
 
 	// Should fail atomically
 	if err == nil {

--- a/tests/hooks_examples_test.go
+++ b/tests/hooks_examples_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// expectedHookEvents is the canonical list of hook event names exposed by the
+// HookManager (see core/hooks.go). The example files must cover ALL of them
+// (even if disabled by default) so a user copying the example gets a complete
+// reference for the events the server can dispatch.
+//
+// Keep in sync with the HookEvent constants in core/hooks.go.
+var expectedHookEvents = []string{
+	"pre-write", "post-write",
+	"pre-edit", "post-edit",
+	"pre-delete", "post-delete",
+	"pre-create", "post-create",
+	"pre-move", "post-move",
+	"pre-copy", "post-copy",
+	"pre-read", "post-read",
+	"pre-search", "post-search",
+}
+
+// loadHookConfig loads a hooks JSON file from the project root's examples/
+// directory. The tests run from the project root (go test ./tests/...).
+func loadHookConfig(t *testing.T, name string) map[string]interface{} {
+	t.Helper()
+	// Walk up from the test binary's working directory to the project root.
+	// The tests are in <project>/tests/ and the examples are in <project>/examples/.
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Try the current directory first (typical: go test from project root),
+	// then walk up to find the examples/ directory.
+	candidates := []string{
+		filepath.Join(wd, "examples", name),
+		filepath.Join(wd, "..", "examples", name),
+		filepath.Join(wd, "..", "..", "examples", name),
+	}
+	var path string
+	for _, c := range candidates {
+		if _, err := os.Stat(c); err == nil {
+			path = c
+			break
+		}
+	}
+	if path == "" {
+		t.Skipf("examples/%s not found (looked in: %v)", name, candidates)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var cfg map[string]interface{}
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("parse %s: %v (file is not valid JSON — this is the bug that prompted this test)", path, err)
+	}
+	return cfg
+}
+
+// TestHooksExampleJSONIsValid guards against the regression of duplicate
+// content being pasted into examples/hooks.example.json (the file is the
+// primary copy-paste template for users; if it's broken, the user's setup
+// breaks too).
+func TestHooksExampleJSONIsValid(t *testing.T) {
+	cfg := loadHookConfig(t, "hooks.example.json")
+	hooks, ok := cfg["hooks"].(map[string]interface{})
+	if !ok {
+		t.Fatal("hooks.example.json: top-level \"hooks\" object missing or wrong type")
+	}
+	// Must cover every event (even if disabled)
+	for _, evt := range expectedHookEvents {
+		if _, ok := hooks[evt]; !ok {
+			t.Errorf("hooks.example.json: missing event %q (must be present in the reference template, even if all entries are disabled)", evt)
+		}
+	}
+}
+
+// TestHooksTestJSONIsValid guards the same for the testing config.
+func TestHooksTestJSONIsValid(t *testing.T) {
+	cfg := loadHookConfig(t, "hooks-test.json")
+	hooks, ok := cfg["hooks"].(map[string]interface{})
+	if !ok {
+		t.Fatal("hooks-test.json: top-level \"hooks\" object missing or wrong type")
+	}
+	for _, evt := range expectedHookEvents {
+		if _, ok := hooks[evt]; !ok {
+			t.Errorf("hooks-test.json: missing event %q", evt)
+		}
+	}
+}
+
+// TestHooksExampleHasNoDuplicateStructure is a focused regression test: in
+// the original broken file, the JSON had duplicate content after the closing
+// `}` of the root object, which made the file invalid. The fix trims it back
+// to a single well-formed object. This test detects the same class of
+// corruption (extra trailing content after the root) on either example file.
+func TestHooksExampleHasNoDuplicateStructure(t *testing.T) {
+	wd, _ := os.Getwd()
+	path := filepath.Join(wd, "examples", "hooks.example.json")
+	if _, err := os.Stat(path); err != nil {
+		path = filepath.Join(wd, "..", "examples", "hooks.example.json")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Skip("hooks.example.json not found")
+	}
+	// json.Unmarshal into interface{} is lenient (accepts trailing junk), so
+	// instead check that a re-marshal of the parsed root round-trips byte-
+	// equal to the input. If duplicate content was appended, the round-trip
+	// length will differ.
+	var parsed interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	roundTrip, err := json.MarshalIndent(parsed, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	// Account for the trailing newline that Go's json.Marshal adds (the
+	// original file ends without one).
+	if len(roundTrip)+1 != len(data) && len(roundTrip) != len(data) {
+		t.Errorf("round-trip length mismatch: input %d bytes, re-marshal %d bytes — likely trailing junk", len(data), len(roundTrip))
+	}
+}

--- a/tests/multi_edit_expected_hash_test.go
+++ b/tests/multi_edit_expected_hash_test.go
@@ -1,0 +1,234 @@
+package main
+
+// Regression tests for issue #24 — multi_edit missing OCC stale-read
+// protection (Improvement B3 parity with edit_file).
+//
+// Before this fix, the `expected_hash` parameter accepted by `edit_file`
+// was NOT declared on the `multi_edit` tool. A consumer editing a file
+// that may be concurrently modified (external editor, another agent
+// calling edit_file) could opt into stale-read protection for a single
+// edit but not for a batch — even though a single hash check before
+// the atomic loop would cover the whole batch.
+
+import (
+	"context"
+	"fmt"
+	"hash/fnv"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mcp/filesystem-ultra/cache"
+	"github.com/mcp/filesystem-ultra/core"
+)
+
+// setupMultiEditHashEngine creates a test engine for the multi_edit
+// expected_hash regression tests (issue #24).
+func setupMultiEditHashEngine(t *testing.T) (*core.UltraFastEngine, string) {
+	t.Helper()
+	tempDir := t.TempDir()
+
+	cacheInstance, err := cache.NewIntelligentCache(1024 * 1024)
+	if err != nil {
+		t.Fatalf("Failed to create cache: %v", err)
+	}
+	config := &core.Config{
+		Cache:        cacheInstance,
+		AllowedPaths: []string{tempDir},
+		ParallelOps:  2,
+	}
+	engine, err := core.NewUltraFastEngine(config)
+	if err != nil {
+		t.Fatalf("Failed to create engine: %v", err)
+	}
+	return engine, tempDir
+}
+
+// fnvHashFile returns the FNV-1a 8-hex-char hash of the file's content,
+// matching the algorithm used by read_file (tools_core.go:267-269) and
+// edit_file (tools_core.go:760-762). Helper used by the regression tests
+// to compute the hash a consumer would have captured from a prior read.
+func fnvHashFile(t *testing.T, path string) string {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read seed: %v", err)
+	}
+	h := fnv.New32a()
+	h.Write(content)
+	return fmt.Sprintf("%08x", h.Sum32())
+}
+
+// TestIssue24_MultiEditExpectedHash_Accepted verifies that multi_edit
+// with a valid `expected_hash` (matching the file's current FNV-1a)
+// proceeds and applies the edits. This is the basic OCC acceptance path,
+// mirroring edit_file's behavior (TestExpectedHash_Accepted).
+func TestIssue24_MultiEditExpectedHash_Accepted(t *testing.T) {
+	engine, tempDir := setupMultiEditHashEngine(t)
+	ctx := context.Background()
+
+	filePath := filepath.Join(tempDir, "occ_accepted.txt")
+	if err := os.WriteFile(filePath, []byte("foo bar\nbaz qux\n"), 0644); err != nil {
+		t.Fatalf("write seed: %v", err)
+	}
+
+	// Compute the hash a consumer would have captured from a prior read.
+	hash := fnvHashFile(t, filePath)
+
+	edits := []core.MultiEditOperation{
+		{OldText: "foo bar", NewText: "FOO BAR"},
+		{OldText: "baz qux", NewText: "BAZ QUX"},
+	}
+
+	result, err := engine.MultiEdit(ctx, filePath, edits, false, false, false, hash)
+	if err != nil {
+		t.Fatalf("MultiEdit with valid expected_hash should succeed, got: %v", err)
+	}
+	if result.SuccessfulEdits != 2 {
+		t.Errorf("expected 2 successful edits, got %d (errors=%v)",
+			result.SuccessfulEdits, result.Errors)
+	}
+
+	// Verify the file was actually modified
+	after, _ := os.ReadFile(filePath)
+	if !strings.Contains(string(after), "FOO BAR") || !strings.Contains(string(after), "BAZ QUX") {
+		t.Errorf("file was not modified: %s", after)
+	}
+}
+
+// TestIssue24_MultiEditExpectedHash_Rejected_StaleEdit verifies that
+// multi_edit with a stale `expected_hash` (file changed since the
+// consumer's last read) is rejected with the EXACT same error string
+// edit_file uses, and that the file is NOT modified — the whole batch
+// rolls back atomically. This is the OCC stale-edit protection.
+func TestIssue24_MultiEditExpectedHash_Rejected_StaleEdit(t *testing.T) {
+	engine, tempDir := setupMultiEditHashEngine(t)
+	ctx := context.Background()
+
+	filePath := filepath.Join(tempDir, "occ_stale.txt")
+	original := []byte("alpha\nbeta\ngamma\n")
+	if err := os.WriteFile(filePath, original, 0644); err != nil {
+		t.Fatalf("write seed: %v", err)
+	}
+
+	// Capture the hash as a consumer would from a read_file call.
+	staleHash := fnvHashFile(t, filePath)
+
+	// Simulate a concurrent write: the file changes between the read
+	// (which produced staleHash) and the multi_edit call.
+	if err := os.WriteFile(filePath, []byte("DIFFERENT CONTENT\n"), 0644); err != nil {
+		t.Fatalf("concurrent write: %v", err)
+	}
+
+	edits := []core.MultiEditOperation{
+		{OldText: "alpha", NewText: "ALPHA"},
+		{OldText: "beta", NewText: "BETA"},
+	}
+
+	// The OCC check rejects the whole batch with "stale edit:" — no edits apply.
+	_, err := engine.MultiEdit(ctx, filePath, edits, false, false, false, staleHash)
+	if err == nil {
+		t.Fatal("MultiEdit with stale expected_hash should return error, got nil")
+	}
+
+	// Error string must mention the OCC signature so consumers can
+	// pattern-match (parity with edit_file's response at
+	// tools_core.go:767-768). The consumer-facing string is the one
+	// edit_file returns to the MCP client.
+	if !strings.Contains(err.Error(), "stale edit") {
+		t.Errorf("error should mention 'stale edit', got: %v", err)
+	}
+	if !strings.Contains(err.Error(), staleHash) {
+		t.Errorf("error should mention the wrong expected hash %q, got: %v", staleHash, err)
+	}
+	if !strings.Contains(err.Error(), "Re-read the file with read_file") {
+		t.Errorf("error should include the read_file retry hint (parity with edit_file), got: %v", err)
+	}
+
+	// File must remain at the post-concurrent-write state — no edits applied.
+	after, _ := os.ReadFile(filePath)
+	if string(after) != "DIFFERENT CONTENT\n" {
+		t.Errorf("file was modified despite stale hash. Expected %q, got %q",
+			"DIFFERENT CONTENT\n", string(after))
+	}
+	if strings.Contains(string(after), "ALPHA") || strings.Contains(string(after), "BETA") {
+		t.Errorf("stale-hash batch leaked partial edits into the file: %s", after)
+	}
+}
+
+// TestIssue24_MultiEditExpectedHash_NotProvided verifies backward
+// compatibility: omitting expected_hash preserves the original
+// behavior — no OCC check is performed, the edits apply. This is
+// the same contract edit_file offers (TestExpectedHash_NotProvided).
+func TestIssue24_MultiEditExpectedHash_NotProvided(t *testing.T) {
+	engine, tempDir := setupMultiEditHashEngine(t)
+	ctx := context.Background()
+
+	filePath := filepath.Join(tempDir, "occ_omitted.txt")
+	if err := os.WriteFile(filePath, []byte("hello world\n"), 0644); err != nil {
+		t.Fatalf("write seed: %v", err)
+	}
+
+	edits := []core.MultiEditOperation{
+		{OldText: "hello", NewText: "goodbye"},
+	}
+
+	// Empty expectedHash ("") disables the OCC check. Edit must apply.
+	result, err := engine.MultiEdit(ctx, filePath, edits, false, false, false, "")
+	if err != nil {
+		t.Fatalf("MultiEdit without expected_hash should succeed, got: %v", err)
+	}
+	if result.SuccessfulEdits != 1 {
+		t.Errorf("expected 1 successful edit, got %d", result.SuccessfulEdits)
+	}
+
+	after, _ := os.ReadFile(filePath)
+	if !strings.Contains(string(after), "goodbye") {
+		t.Errorf("file was not modified: %s", after)
+	}
+}
+
+// TestIssue24_MultiEditExpectedHash_AtomicRollback verifies that the
+// OCC check happens BEFORE the edit loop and the backup creation, so
+// a stale hash never creates an unnecessary backup and never applies
+// any edits — even though the file's current content DOES contain the
+// anchor text. The OCC check is the gate; once it passes (or is
+// skipped), the normal atomic-rollback semantics take over for the
+// per-edit matching.
+func TestIssue24_MultiEditExpectedHash_AtomicRollback(t *testing.T) {
+	engine, tempDir := setupMultiEditHashEngine(t)
+	ctx := context.Background()
+
+	filePath := filepath.Join(tempDir, "occ_atomic.txt")
+	original := []byte("anchor1\nanchor2\nNONEXISTENT_TOKEN\n")
+	if err := os.WriteFile(filePath, original, 0644); err != nil {
+		t.Fatalf("write seed: %v", err)
+	}
+
+	// Use a deliberately wrong (but non-empty) hash to trigger the OCC
+	// rejection — the anchors and the nonexistent token are irrelevant
+	// to the OCC check; the check happens BEFORE the per-edit matching.
+	wrongHash := "deadbeef"
+
+	edits := []core.MultiEditOperation{
+		{OldText: "anchor1", NewText: "ANCHOR1"},
+		{OldText: "anchor2", NewText: "ANCHOR2"},
+		{OldText: "NONEXISTENT_TOKEN", NewText: "REPLACED"},
+	}
+
+	_, err := engine.MultiEdit(ctx, filePath, edits, false, false, false, wrongHash)
+	if err == nil {
+		t.Fatal("MultiEdit with wrong expected_hash should return error, got nil")
+	}
+	if !strings.Contains(err.Error(), "stale edit") {
+		t.Errorf("error should mention 'stale edit', got: %v", err)
+	}
+
+	// File must remain byte-for-byte identical to the original.
+	after, _ := os.ReadFile(filePath)
+	if string(after) != string(original) {
+		t.Errorf("file was modified despite stale hash. Expected %q, got %q",
+			string(original), string(after))
+	}
+}

--- a/tests/multi_edit_occurrences_counter_test.go
+++ b/tests/multi_edit_occurrences_counter_test.go
@@ -85,7 +85,7 @@ func TestIssue21_MultiEditNoticeReplacementsNotZero(t *testing.T) {
 		{OldText: "ANCHOR4", NewText: replacement},
 	}
 
-	result, err := engine.MultiEdit(ctx, filePath, edits, false, false, false)
+	result, err := engine.MultiEdit(ctx, filePath, edits, false, false, false, "")
 	if err != nil {
 		t.Fatalf("MultiEdit returned error: %v", err)
 	}
@@ -150,7 +150,7 @@ func TestIssue21_RiskNoticeClampsPercentAt100(t *testing.T) {
 		},
 	}
 
-	result, err := engine.MultiEdit(ctx, filePath, edits, false, false, false)
+	result, err := engine.MultiEdit(ctx, filePath, edits, false, false, false, "")
 	if err != nil {
 		t.Fatalf("MultiEdit returned error: %v", err)
 	}

--- a/tests/multi_edit_occurrences_counter_test.go
+++ b/tests/multi_edit_occurrences_counter_test.go
@@ -1,0 +1,187 @@
+package main
+
+// Regression tests for issue #21 — multi_edit risk notice displays
+// "0 replacements" instead of the real edit count, and the displayed
+// "% of file" can exceed 100% (e.g. "137% of file") when the honest-
+// scope formula's numerator is larger than the file size.
+//
+// White-box diagnosis (see issue body for full trace):
+//   - calculateMultiEditImpact never assigned impact.Occurrences, so
+//     FormatRiskNotice printed the Go zero value ("0 replacements").
+//   - The honest-scope formula Σ max(|oldText|,|newText|) / fileSize
+//     is a correct upper bound but produces >100% on net insertions;
+//     the notice formatter did not clamp it, so the user-visible text
+//     read as "the file changed by more than 100%" which is wrong.
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mcp/filesystem-ultra/cache"
+	"github.com/mcp/filesystem-ultra/core"
+)
+
+// setupOccurrencesEngine creates a test engine for the multi_edit
+// occurrences-counter regression tests (issue #21).
+func setupOccurrencesEngine(t *testing.T) (*core.UltraFastEngine, string) {
+	t.Helper()
+	tempDir := t.TempDir()
+
+	cacheInstance, err := cache.NewIntelligentCache(1024 * 1024)
+	if err != nil {
+		t.Fatalf("Failed to create cache: %v", err)
+	}
+	config := &core.Config{
+		Cache:        cacheInstance,
+		AllowedPaths: []string{tempDir},
+		ParallelOps:  2,
+	}
+	engine, err := core.NewUltraFastEngine(config)
+	if err != nil {
+		t.Fatalf("Failed to create engine: %v", err)
+	}
+	return engine, tempDir
+}
+
+// TestIssue21_MultiEditNoticeReplacementsNotZero verifies that after a
+// multi_edit that applied N edits, the RiskWarning's "replacements" count
+// reflects N (not 0). Before the fix, calculateMultiEditImpact left
+// aggregateImpact.Occurrences at its Go zero value, and FormatRiskNotice
+// printed "0 replacements" — the same number whether the edits applied
+// or not. This was misleading: a caller reading "0 replacements" could
+// reasonably conclude the operation was a no-op, when in fact the file
+// had been modified.
+func TestIssue21_MultiEditNoticeReplacementsNotZero(t *testing.T) {
+	engine, tempDir := setupOccurrencesEngine(t)
+	ctx := context.Background()
+
+	// Build a 212-byte file with 4 unique anchors separated by padding.
+	// Each edit replaces a 7-byte anchor with a 40-byte replacement, so
+	// scope per edit is 40 bytes → 4 × 40 = 160 bytes total scope.
+	// ChangePercentage ≈ 160/212 ≈ 75% — well above the 20% medium
+	// threshold, which forces FormatRiskNotice to emit the risk line.
+	var b strings.Builder
+	b.WriteString(strings.Repeat("X", 47))
+	b.WriteString("ANCHOR1")
+	b.WriteString(strings.Repeat("X", 47))
+	b.WriteString("ANCHOR2")
+	b.WriteString(strings.Repeat("X", 47))
+	b.WriteString("ANCHOR3")
+	b.WriteString(strings.Repeat("X", 47))
+	b.WriteString("ANCHOR4")
+	filePath := filepath.Join(tempDir, "occurrence_test.txt")
+	if err := os.WriteFile(filePath, []byte(b.String()), 0644); err != nil {
+		t.Fatalf("write seed: %v", err)
+	}
+
+	replacement := "ANCHOR_RENAMED_WITH_LONGER_PAYLOAD"
+	edits := []core.MultiEditOperation{
+		{OldText: "ANCHOR1", NewText: replacement},
+		{OldText: "ANCHOR2", NewText: replacement},
+		{OldText: "ANCHOR3", NewText: replacement},
+		{OldText: "ANCHOR4", NewText: replacement},
+	}
+
+	result, err := engine.MultiEdit(ctx, filePath, edits, false, false, false)
+	if err != nil {
+		t.Fatalf("MultiEdit returned error: %v", err)
+	}
+	if result.SuccessfulEdits != 4 {
+		t.Fatalf("fixture sanity: expected 4 successful edits, got %d (errors=%v)",
+			result.SuccessfulEdits, result.Errors)
+	}
+	if result.RiskWarning == "" {
+		t.Fatalf("fixture sanity: RiskWarning not emitted — adjust the seed so the change exceeds the medium threshold. Got %d edits, %d lines, %d total lines.",
+			result.SuccessfulEdits, result.LinesAffected, result.TotalLines)
+	}
+
+	// Bug-fix assertion: the notice must NOT say "0 replacements" when 4
+	// edits applied. The fix sets aggregateImpact.Occurrences from the real
+	// per-edit ReplacementCount sum.
+	if strings.Contains(result.RiskWarning, "0 replacements") {
+		t.Errorf("RiskWarning still shows '0 replacements' despite %d successful edits:\n%s",
+			result.SuccessfulEdits, result.RiskWarning)
+	}
+	if !strings.Contains(result.RiskWarning, "4 replacements") {
+		t.Errorf("RiskWarning should mention '4 replacements' (one per applied edit), got:\n%s",
+			result.RiskWarning)
+	}
+
+	// Sanity: every edit renamed exactly one occurrence (the token is
+	// unique per line), so the per-edit ReplacementCount is 1, and the
+	// sum is 4. The notice text confirms that.
+	t.Logf("RiskWarning emitted:\n%s", result.RiskWarning)
+}
+
+// TestIssue21_RiskNoticeClampsPercentAt100 verifies that when the
+// honest-scope formula yields a ChangePercentage > 100, the notice
+// string is capped at "100% of file". The change_percentage field and
+// the RiskLevel are not modified — only the displayed value.
+//
+// Honest-scope can exceed 100% on net insertions: replacing a 6-byte
+// anchor with a 600-byte blob in a 200-byte file yields
+// (6 + 600) / 200 × 100 = 303% (the formula uses max(old,new), so it's
+// 600/200 = 300%). The internal RiskLevel and CharactersChanged remain
+// the honest upper bound; only the user-visible "X% of file" text is
+// clamped, so the magnitude word ("very large edit") still encodes
+// severity.
+func TestIssue21_RiskNoticeClampsPercentAt100(t *testing.T) {
+	engine, tempDir := setupOccurrencesEngine(t)
+	ctx := context.Background()
+
+	// 200-byte file with a single, unique anchor.
+	// Layout: 97 X's, "ANCHOR" (6 bytes), 97 X's → 200 bytes.
+	var b strings.Builder
+	b.WriteString(strings.Repeat("X", 97))
+	b.WriteString("ANCHOR")
+	b.WriteString(strings.Repeat("X", 97))
+	filePath := filepath.Join(tempDir, "scope_overshoot.txt")
+	if err := os.WriteFile(filePath, []byte(b.String()), 0644); err != nil {
+		t.Fatalf("write seed: %v", err)
+	}
+
+	edits := []core.MultiEditOperation{
+		{
+			OldText: "ANCHOR",                 // 6 bytes
+			NewText: strings.Repeat("Y", 600), // 600 bytes — net insertion
+		},
+	}
+
+	result, err := engine.MultiEdit(ctx, filePath, edits, false, false, false)
+	if err != nil {
+		t.Fatalf("MultiEdit returned error: %v", err)
+	}
+	if result.SuccessfulEdits != 1 {
+		t.Fatalf("fixture sanity: expected 1 successful edit, got %d (errors=%v)",
+			result.SuccessfulEdits, result.Errors)
+	}
+	if result.RiskWarning == "" {
+		t.Fatalf("fixture sanity: RiskWarning not emitted — adjust the seed so the change exceeds 10%% of the file")
+	}
+
+	// The honest-scope would be 300% here. The notice must NOT show the
+	// raw uncapped value. Allowed forms: "100% of file".
+	for _, bad := range []string{"300%", "299%", "298%"} {
+		if strings.Contains(result.RiskWarning, bad) {
+			t.Errorf("RiskWarning contains uncapped percentage %q (should be clamped to 100%%):\n%s",
+				bad, result.RiskWarning)
+		}
+	}
+	if !strings.Contains(result.RiskWarning, "100% of file") {
+		t.Errorf("RiskWarning should contain '100%% of file' (the cap), got:\n%s",
+			result.RiskWarning)
+	}
+
+	// Magnitude must still read as a high-severity edit (the cap is
+	// display-only; the RiskLevel and magnitude are unchanged).
+	if !strings.Contains(result.RiskWarning, "very large edit") &&
+		!strings.Contains(result.RiskWarning, "large edit") {
+		t.Errorf("RiskWarning should still convey severity via magnitude word, got:\n%s",
+			result.RiskWarning)
+	}
+
+	t.Logf("RiskWarning emitted:\n%s", result.RiskWarning)
+}

--- a/tests/undo_step_through_test.go
+++ b/tests/undo_step_through_test.go
@@ -236,7 +236,7 @@ func TestUndoChain_MultiEditChain(t *testing.T) {
 		{OldText: "line1", NewText: "M1A"},
 		{OldText: "line2", NewText: "M1B"},
 	}
-	r1, err := engine.MultiEdit(context.Background(), testFile, edits1, false, false, false)
+	r1, err := engine.MultiEdit(context.Background(), testFile, edits1, false, false, false, "")
 	if err != nil {
 		t.Fatalf("First MultiEdit failed: %v", err)
 	}
@@ -247,7 +247,7 @@ func TestUndoChain_MultiEditChain(t *testing.T) {
 		{OldText: "line3", NewText: "M2A"},
 		{OldText: "line4", NewText: "M2B"},
 	}
-	r2, err := engine.MultiEdit(context.Background(), testFile, edits2, false, false, false)
+	r2, err := engine.MultiEdit(context.Background(), testFile, edits2, false, false, false, "")
 	if err != nil {
 		t.Fatalf("Second MultiEdit failed: %v", err)
 	}

--- a/tools_batch.go
+++ b/tools_batch.go
@@ -30,6 +30,7 @@ func registerBatchTools(reg *toolRegistry) {
 		mcp.WithString("edits_json", mcp.Required(), mcp.Description("JSON array of edits: [{\"old_text\": \"...\", \"new_text\": \"...\"}, ...]. Also accepts old_str/new_str as aliases.")),
 		mcp.WithBoolean("force", mcp.Description("Force operation even if CRITICAL risk (default: false)")),
 		mcp.WithBoolean("tolerant_whitespace", mcp.Description("Apply tolerant_whitespace semantics to all edits in the batch (1 tab = 4 spaces, CRLF = LF). Default: false.")),
+		mcp.WithString("expected_hash", mcp.Description("Optional. The content_hash returned by the last read_file. If the file's current hash doesn't match, the multi_edit is rejected so the model can re-read first. Same OCC token as edit_file (Improvement B3), atomic over the whole batch.")),
 	)
 	reg.addTool(multiEditTool, auditWrap(engine, "multi_edit", func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		path, err := request.RequireString("path")
@@ -106,9 +107,10 @@ func registerBatchTools(reg *toolRegistry) {
 			return mcp.NewToolResultError("edits array cannot be empty"), nil
 		}
 
-		// Extract force and dry_run parameters
+		// Extract force, dry_run, and expected_hash parameters
 		force := false
 		dryRun := false
+		expectedHash := ""
 		if args != nil {
 			if f, ok := args["force"].(bool); ok {
 				force = f
@@ -116,10 +118,13 @@ func registerBatchTools(reg *toolRegistry) {
 			if dr, ok := args["dry_run"].(bool); ok {
 				dryRun = dr
 			}
+			if eh, ok := args["expected_hash"].(string); ok {
+				expectedHash = eh
+			}
 		}
 
 		// Execute multi-edit
-		result, err := engine.MultiEdit(ctx, path, edits, force, dryRun, false)
+		result, err := engine.MultiEdit(ctx, path, edits, force, dryRun, false, expectedHash)
 		if err != nil {
 			// Bug #27: If result is non-nil, this is an atomic rollback — include backup_id and details
 			if result != nil && result.BackupID != "" {

--- a/tools_core.go
+++ b/tools_core.go
@@ -258,16 +258,27 @@ func registerCoreTools(reg *toolRegistry) {
 		// Record read for stale-read detection in feedback system
 		core.RecordRead(core.NormalizePath(path))
 
-		// Compute FNV-1a content hash (8 hex chars) and append as a comment
-		// footer. The model can echo it back via edit_file(expected_hash:"...")
-		// to detect stale reads (improvement B3: prevents 6 stale-edit cycles
-		// observed in 12 days of log analysis).
-		// The `#` makes it look like a comment in many file formats so it
-		// doesn't pollute the user's view of the actual content.
+		// Compute FNV-1a content hash (8 hex chars). The hash is the OCC token
+		// (Improvement B3) — the model can echo it back via edit_file /
+		// multi_edit expected_hash to detect stale reads and prevent lost
+		// updates under concurrent writes.
+		//
+		// Bug B1 fix (#23): the hash is no longer appended as a `# content_hash:`
+		// line at the end of the response body. That trailer was visually
+		// indistinguishable from legitimate Markdown content (same `# comment`
+		// syntax), so consumers — human or AI — copied it as an `old_text`
+		// anchor in `edit_file` / `multi_edit`, got `no matches found`, and
+		// for `multi_edit` (atomic) the whole batch rolled back. The hash is
+		// now returned as a structured response field, so it never appears
+		// as content. Clients that understand `structuredContent` read it
+		// from there; clients that don't see only the file body.
+		//
+		// Hash is computed on the ORIGINAL content (before truncation) so
+		// it remains a valid OCC token against the file on disk regardless
+		// of how much of the body we return to the consumer.
 		h := fnv.New32a()
 		h.Write([]byte(content))
 		contentHash := fmt.Sprintf("%08x", h.Sum32())
-		content = content + "\n# content_hash: " + contentHash
 
 		// Apply truncation if explicitly requested
 		if maxLines > 0 || mode != "all" {
@@ -283,7 +294,14 @@ func registerCoreTools(reg *toolRegistry) {
 		core.SetFileLinesTotal(ctx, totalLines)
 		core.SetLinesRead(ctx, totalLines)
 
-		return mcp.NewToolResultText(content), nil
+		// Return the body as plain text (NO trailer) and the hash as a
+		// structured field. Fallback text for naive clients is the file
+		// body — they never see a `# content_hash:` line, so they can't
+		// mistake it for content.
+		return mcp.NewToolResultStructured(
+			map[string]any{"content_hash": contentHash},
+			content,
+		), nil
 	})
 	reg.addTool(readFileTool, reg.readFileHandler)
 


### PR DESCRIPTION
Fixes #24.

## Summary

The `expected_hash` parameter (Improvement B3 OCC token for stale-read protection) was only declared on `edit_file`, not on `multi_edit`. A consumer editing a file that may be concurrently modified could opt into stale-read protection for a single edit but not for a batch, even though a single hash check before the atomic loop would cover the whole batch.

## Fix

`multi_edit` now declares the `expected_hash` string parameter; the handler reads it and passes it to the engine. The engine computes FNV-1a of the file at call time and, on mismatch, returns the **exact same** error string `edit_file` uses:

```
stale edit: file content changed since read (expected hash: X, actual: Y). Re-read the file with read_file to get the current content_hash, then retry.
```

So a consumer that pattern-matches on `stale edit:` retries the same way for both tools.

## Where the check sits

The OCC check runs immediately after the file is read, **before** context validation, impact calculation, and the backup. A stale hash never creates an unnecessary backup and never applies any edits.

## Backward compatibility

`expectedHash == ""` disables the check. All 25+ existing `engine.MultiEdit(...)` call sites (tests + pipeline executor) were updated to pass `""` for the new parameter.

## Tests

`tests/multi_edit_expected_hash_test.go` (4 cases):
- `_Accepted` — valid hash, edits apply
- `_Rejected_StaleEdit` — stale hash, error string matches edit_file's, file unchanged, no partial edits
- `_NotProvided` — empty hash, backward compat
- `_AtomicRollback` — wrong hash, file byte-identical to original (verifies check runs before the edit loop)

```bash
go test ./tests/ -run "TestIssue24_" -v   # 4/4 pass
go test ./...                                # full suite green
```

## Migration

The signature change is additive. External callers using `core.UltraFastEngine.MultiEdit` directly (rare — it's a low-level API) need to add the new trailing argument. The MCP tool surface gains an optional parameter, no behavior change for existing clients.