### PR TITLE
fix(tests): make TestHooksExampleHasNoDuplicateStructure platform-independent (Windows CRLF)

### DIFF
--- a/tests/hooks_examples_test.go
+++ b/tests/hooks_examples_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -121,6 +122,13 @@ func TestHooksExampleHasNoDuplicateStructure(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
+	// Normalize both sides to LF line endings before comparing lengths.
+	// On Windows, `core.autocrlf=true` may checkout the file with CRLF, which
+	// inflates len(data) by ~1 byte per line (322 lines = +322 bytes here) and
+	// makes the round-trip comparison flaky across platforms. The re-marshaled
+	// JSON uses LF, so the only fair comparison is after normalization.
+	data = []byte(strings.ReplaceAll(string(data), "\r\n", "\n"))
+	roundTrip = []byte(strings.ReplaceAll(string(roundTrip), "\r\n", "\n"))
 	// Account for the trailing newline that Go's json.Marshal adds (the
 	// original file ends without one).
 	if len(roundTrip)+1 != len(data) && len(roundTrip) != len(data) {


### PR DESCRIPTION
Post-merge follow-up to #20.

## What

The test in `tests/hooks_examples_test.go` compares the on-disk `hooks.example.json` size against a `json.MarshalIndent` re-marshal of the parsed root, treating any size mismatch as "likely trailing junk". On Windows, `core.autocrlf=true` checks the file out with CRLF line endings, inflating `len(data)` by ~1 byte per line (322 lines = +322 bytes) and making the test fail on Windows-only.

Linux CI was reading the file with LF and the test passed — which is why this slipped through PR #20's CI. After merge to main, the test fails on this Windows checkout.

## Fix

Normalize both sides to LF before comparing lengths. The test's intent ("no trailing junk after the root") is preserved — duplicate content after `}` would still be detected — but a uniform line-ending policy makes the comparison fair across platforms.

## Verification

```bash
go test ./tests/ -run TestHooksExampleHasNoDuplicateStructure -v   # PASS
go test ./...                                                       # full suite green
```